### PR TITLE
Implement specific flags for auto saving and restoring and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,27 @@ let g:auto_session_root_dir = path/to/my/custom/dir
 " or use lua
 lua << EOF
 local opts = {
-  -- Sets the log level of the plugin (debug, info, error)
-  logLevel = vim.g.auto_session_log_level or AutoSession.conf.logLevel or 'info',
-  -- Root dir where sessions will be stored
+  log_level = 'info',
+  auto_session_enable_last_session = false,
   auto_session_root_dir = vim.fn.stdpath('data').."/sessions/",
-  -- Enables/disables auto save/restore
-  auto_session_enabled = true
+  auto_session_enabled = true,
+  auto_save_enabled = true,
+  auto_restore_enabled = true
 }
 
 require('auto-session').setup(opts)
 EOF
 ```
+### Options
+| Config                            | Options                   | Default                               |
+| --------------------------------- | ------------------------- | ------------------------------------- |
+| log_level                         | 'debug', 'info', 'error'  | 'info'                                |
+| auto_session_enable_last_session  | false, true               | false                                 |
+| auto_session_root_dir             | "/some/path/you/want"     | vim.fn.stdpath('data').."/sessions/"  |
+| auto_session_enabled              | false, true               | true                                  |
+| auto_save_enabled                 | false, true, nil          | nil                                   |
+| auto_restore_enabled              | false, true, nil          | nil                                   |
+
 
 ### Last Session
 This optional feature enables the keeping track and loading of the last session.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ require('auto-session').setup(opts)
 EOF
 ```
 ### Options
-| Config                            | Options                   | Default                               |
-| --------------------------------- | ------------------------- | ------------------------------------- |
-| log_level                         | 'debug', 'info', 'error'  | 'info'                                |
-| auto_session_enable_last_session  | false, true               | false                                 |
-| auto_session_root_dir             | "/some/path/you/want"     | vim.fn.stdpath('data').."/sessions/"  |
-| auto_session_enabled              | false, true               | true                                  |
-| auto_save_enabled                 | false, true, nil          | nil                                   |
-| auto_restore_enabled              | false, true, nil          | nil                                   |
+| Config                            | Options                   | Default                               | Description                                                     |
+| --------------------------------- | ------------------------- | ------------------------------------- | ----------------------------------------------------------------|
+| log_level                         | 'debug', 'info', 'error'  | 'info'                                | Sets the log level of the plugin                                |
+| auto_session_enable_last_session  | false, true               | false                                 | Loads the last loaded session if session for cwd does not exist |
+| auto_session_root_dir             | "/some/path/you/want"     | vim.fn.stdpath('data').."/sessions/"  | Changes the root dir for sessions                               |
+| auto_session_enabled              | false, true               | true                                  | Enables/disables the plugin's auto save _and_ restore features  |
+| auto_save_enabled                 | false, true, nil          | nil                                   | Enables/disables auto saving                                    |
+| auto_restore_enabled              | false, true, nil          | nil                                   | Enables/disables auto restoring                                 |
 
 
 ### Last Session

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -2,7 +2,7 @@ local Config = {}
 local Lib = {
   logger = {},
   conf = {
-    logLevel = false
+    log_level = false
   },
   Config = Config,
   _VIM_FALSE = 0,
@@ -116,14 +116,14 @@ end
 
 -- Logger =========================================================
 function Lib.logger.debug(...)
-  if Lib.conf.logLevel == 'debug' then
+  if Lib.conf.log_level == 'debug' then
     print(...)
   end
 end
 
 function Lib.logger.info(...)
   local valid_values = {'info', 'debug'}
-  if has_value(valid_values, Lib.conf.logLevel) then
+  if has_value(valid_values, Lib.conf.log_level) then
     print(...)
   end
 end

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -42,7 +42,6 @@ function AutoSession.setup(config)
   })
 end
 
--- TODO: finish is_enabled feature
 local function is_enabled()
   if vim.g.auto_session_enabled ~= nil then
     return vim.g.auto_session_enabled == Lib._VIM_TRUE
@@ -54,7 +53,9 @@ local function is_enabled()
 end
 
 local auto_save = function()
-  if AutoSession.conf.auto_save_enabled ~= nil then
+  if vim.g.auto_session_enabled ~= nil then
+    return vim.g.auto_save_enabled == Lib._VIM_TRUE
+  elseif AutoSession.conf.auto_save_enabled ~= nil then
     return AutoSession.conf.auto_save_enabled
   else
     return next(vim.fn.argv()) == nil
@@ -62,7 +63,9 @@ local auto_save = function()
 end
 
 local auto_restore = function()
-  if AutoSession.conf.auto_restore_enabled ~= nil then
+  if vim.g.auto_restore_enabled ~= nil then
+    return vim.g.auto_restore_enabled == Lib._VIM_TRUE
+  elseif AutoSession.conf.auto_restore_enabled ~= nil then
     return AutoSession.conf.auto_restore_enabled
   else
     return next(vim.fn.argv()) == nil
@@ -93,10 +96,8 @@ end
 
 ------ MAIN FUNCTIONS ------
 function AutoSession.AutoSaveSession(sessions_dir)
-  if is_enabled() then
-    if auto_save() then
-      AutoSession.SaveSession(sessions_dir, true)
-    end
+  if is_enabled() and auto_save() then
+    AutoSession.SaveSession(sessions_dir, true)
   end
 end
 
@@ -147,10 +148,8 @@ end
 
 -- This function avoids calling RestoreSession automatically when argv is not nil.
 function AutoSession.AutoRestoreSession(sessions_dir)
-  if is_enabled() then
-    if auto_restore() then
-      AutoSession.RestoreSession(sessions_dir)
-    end
+  if is_enabled() and auto_restore() then
+    AutoSession.RestoreSession(sessions_dir)
   end
 end
 

--- a/plugin/auto-session.vim
+++ b/plugin/auto-session.vim
@@ -24,8 +24,9 @@ aug END
 
 augroup autosession
   autocmd!
-  autocmd VimEnter * nested if g:in_pager_mode == 0 | call LuaAutoRestoreSession() | endif
-  autocmd VimLeave * if g:in_pager_mode == 0 | call LuaAutoSaveSession() | endif
+  autocmd VimEnter * nested call LuaAutoRestoreSession()
+  autocmd VimLeave * call LuaAutoSaveSession()
+
   " TODO: Experiment with saving session on more than just VimEnter and VimLeave
   " autocmd BufWinEnter * if g:in_pager_mode == 0 | call LuaAutoSaveSession() | endif
   " autocmd BufWinLeave * if g:in_pager_mode == 0 | call LuaAutoSaveSession() | endif


### PR DESCRIPTION
New flags should start as nil, unless the default behaviour of the
plugin is not the desired behaviour.

Setting the `auto_save_enabled = true` for example allows for a session
to be saved even when vim was first opened as a "pager". i.e passing in
parameters for reading from stdin.

Closes #13.