### PR TITLE
Fix auto save/restore getting triggered when in pager mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ local opts = {
   auto_session_enable_last_session = false,
   auto_session_root_dir = vim.fn.stdpath('data').."/sessions/",
   auto_session_enabled = true,
-  auto_save_enabled = true,
-  auto_restore_enabled = true,
-  auto_session_suppress_dirs = {}
+  auto_save_enabled = nil,
+  auto_restore_enabled = nil,
+  auto_session_suppress_dirs = nil
 }
 
 require('auto-session').setup(opts)

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -53,26 +53,40 @@ local function is_enabled()
   return true
 end
 
-local in_pager_mode = next(vim.fn.argv()) ~= nil -- Neovim was opened with args
+local pager_mode = nil
+local in_pager_mode = function()
+  if pager_mode ~= nil then return pager_mode end -- Only evaluate this once
+
+  local opened_with_args = next(vim.fn.argv()) ~= nil -- Neovim was opened with args
+  local reading_from_stdin = vim.g.in_pager_mode == Lib._VIM_TRUE -- Set from StdinReadPre
+
+  pager_mode = opened_with_args or reading_from_stdin
+  Lib.logger.debug("==== Pager mode", pager_mode)
+  return pager_mode
+end
 
 local auto_save = function()
-  if in_pager_mode then return false end
+  if in_pager_mode() then return false end
 
   if vim.g.auto_session_enabled ~= nil then
     return vim.g.auto_save_enabled == Lib._VIM_TRUE
   elseif AutoSession.conf.auto_save_enabled ~= nil then
     return AutoSession.conf.auto_save_enabled
   end
+
+  return true
 end
 
 local auto_restore = function()
-  if in_pager_mode then return false end
+  if in_pager_mode() then return false end
 
   if vim.g.auto_restore_enabled ~= nil then
     return vim.g.auto_restore_enabled == Lib._VIM_TRUE
   elseif AutoSession.conf.auto_restore_enabled ~= nil then
     return AutoSession.conf.auto_restore_enabled
   end
+
+  return true
 end
 
 local function suppress_session()

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -53,7 +53,7 @@ local function is_enabled()
   return true
 end
 
-local in_pager_mode = next(vim.fn.argv()) == nil -- Neovim was opened with zero args
+local in_pager_mode = next(vim.fn.argv()) ~= nil -- Neovim was opened with args
 
 local auto_save = function()
   if in_pager_mode then return false end

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -53,23 +53,25 @@ local function is_enabled()
   return true
 end
 
+local in_pager_mode = next(vim.fn.argv()) == nil -- Neovim was opened with zero args
+
 local auto_save = function()
+  if in_pager_mode then return false end
+
   if vim.g.auto_session_enabled ~= nil then
     return vim.g.auto_save_enabled == Lib._VIM_TRUE
   elseif AutoSession.conf.auto_save_enabled ~= nil then
     return AutoSession.conf.auto_save_enabled
-  else
-    return next(vim.fn.argv()) == nil
   end
 end
 
 local auto_restore = function()
+  if in_pager_mode then return false end
+
   if vim.g.auto_restore_enabled ~= nil then
     return vim.g.auto_restore_enabled == Lib._VIM_TRUE
   elseif AutoSession.conf.auto_restore_enabled ~= nil then
     return AutoSession.conf.auto_restore_enabled
-  else
-    return next(vim.fn.argv()) == nil
   end
 end
 


### PR DESCRIPTION
Switched the evaluation of vim being opened with args or not to the
begining of the auto_save and auto_restore function flags.

Closes #24 