### PR TITLE
Disable auto saving when sourcing a session errors out.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Auto Session takes advantage of Neovim's existing session management capabilitie
 4. Any session saving and restoration takes into consideration the current working directory `cwd`.
 5. When piping to `nvim`, e.g: `cat myfile | nvim`, auto-session behaves like #2.
 
+:warning: Please note that if there are errors in your config, restoring the session might fail, if that happens, auto session will then disable auto saving for the current session.
+Manually saving a session can still be done by calling `:SaveSession`.
+
 # Installation
 Any plugin manager should do, I use [Plug](https://github.com/junegunn/vim-plug).
 

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -216,7 +216,10 @@ function AutoSession.RestoreSession(sessions_dir_or_file)
     local success, result = pcall(vim.cmd, cmd)
 
     if not success then
-      Lib.logger.error("Error restoring session, the session might be corrupted. Disabling auto save. "..result)
+      Lib.logger.error([[
+        Error restoring session! The session might be corrupted.
+        Disabling auto save. Please check for errors in your config. Error: 
+      ]]..result)
       AutoSession.conf.auto_save_enabled = false
       return
     end

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -213,7 +213,14 @@ function AutoSession.RestoreSession(sessions_dir_or_file)
     run_hook_cmds(pre_cmds, "pre-restore")
 
     local cmd = "source "..file_path
-    vim.cmd(cmd)
+    local success, result = pcall(vim.cmd, cmd)
+
+    if not success then
+      Lib.logger.error("Error restoring session, the session might be corrupted. Disabling auto save.", result)
+      AutoSession.conf.auto_save_enabled = false
+      return
+    end
+
     Lib.logger.info("Session restored from "..file_path)
 
     local post_cmds = AutoSession.get_cmds("post_restore")

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -216,7 +216,7 @@ function AutoSession.RestoreSession(sessions_dir_or_file)
     local success, result = pcall(vim.cmd, cmd)
 
     if not success then
-      Lib.logger.error("Error restoring session, the session might be corrupted. Disabling auto save.", result)
+      Lib.logger.error("Error restoring session, the session might be corrupted. Disabling auto save. "..result)
       AutoSession.conf.auto_save_enabled = false
       return
     end


### PR DESCRIPTION
Disabling happens by setting the auto_save_enabled flag to false.
The auto save function still runs but checks the flag before actually
saving.

Currently if entering this state only restarting Neovim with an
uncorrupted or non-existent session will bring back auto saving.

Closes #27