### PR TITLE
Friendlier command completion

### DIFF
--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -97,20 +97,36 @@ function Lib.init_file(file_path)
   end
 end
 
-local function win32_escaped_cwd(cwd)
-  cwd = cwd:gsub(':', '++')
+local function win32_escaped_dir(dir)
+  dir = dir:gsub('++', ':')
   if not vim.o.shellslash then
-    cwd = cwd:gsub("\\", "\\%%")
+    dir = dir:gsub("%%", "\\")
   end
 
-  return cwd
+  return dir
+end
+
+local function win32_unescaped_dir(dir)
+  dir = dir:gsub(':', '++')
+  if not vim.o.shellslash then
+    dir = dir:gsub("\\", "\\%%")
+  end
+
+  return dir
 end
 
 local IS_WIN32 = vim.fn.has('win32') == Lib._VIM_TRUE
 
+function Lib.unescape_dir(dir)
+  return IS_WIN32 and win32_unescaped_dir(dir) or dir:gsub("%%", "/")
+end
+
+function Lib.escape_dir(dir)
+  return IS_WIN32 and win32_escaped_dir(dir) or dir:gsub("/", "\\%%")
+end
+
 function Lib.escaped_session_name_from_cwd()
-  local cwd = vim.fn.getcwd()
-  return IS_WIN32 and win32_escaped_cwd(cwd) or cwd:gsub("/", "\\%%")
+  return Lib.escape_dir(vim.fn.getcwd())
 end
 
 local function get_win32_legacy_cwd(cwd)

--- a/plugin/auto-session.vim
+++ b/plugin/auto-session.vim
@@ -7,7 +7,7 @@ let g:in_pager_mode = 0
 
 let LuaSaveSession = luaeval('require("auto-session").SaveSession')
 let LuaRestoreSession = luaeval('require("auto-session").RestoreSession')
-let LuaDeleteSession = luaeval('require("auto-session").DeleteSession')
+let LuaDeleteSessionByName = luaeval('require("auto-session").DeleteSessionByName')
 
 let LuaAutoSaveSession = luaeval('require("auto-session").AutoSaveSession')
 let LuaAutoRestoreSession = luaeval('require("auto-session").AutoRestoreSession')
@@ -19,7 +19,7 @@ endfunction
 " Available commands
 command! -nargs=* SaveSession call LuaSaveSession(expand('<args>'))
 command! -nargs=* RestoreSession call LuaRestoreSession(expand('<args>'))
-command! -nargs=* -complete=custom,CompleteSessions DeleteSession call LuaDeleteSession(expand('<args>'))
+command! -nargs=* -complete=custom,CompleteSessions DeleteSession call LuaDeleteSessionByName(<f-args>)
 
 aug StdIn
   autocmd!


### PR DESCRIPTION
Show the actual unescaped 'name' of the session instead of the full path
to the session + escaped name when showing completion options.