### PR TITLE
unescape windows path for save and restore session operation

### DIFF
--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -126,7 +126,7 @@ function Lib.escape_dir(dir)
 end
 
 function Lib.escaped_session_name_from_cwd()
-  return Lib.escape_dir(vim.fn.getcwd())
+  return IS_WIN32 and Lib.unescape_dir(vim.fn.getcwd()) or Lib.escape_dir(vim.fn.getcwd()) 
 end
 
 local function get_win32_legacy_cwd(cwd)


### PR DESCRIPTION
We need to call `unescape_dir` in windows.

Before
> Session saved at C:\Users\denil\AppData\Local\nvim-data/sessions/C:\Users\denil.vim
...site\pack\packer\start\auto-session\lua\auto-session.lua:173: Vim(mksession):E190: Cannot open "C:\Users\denil\AppData\Local\nvim-data/sessions/C:\Users\denil.vim" for writing

After
> Session saved at C:\Users\denil\AppData\Local\nvim-data/sessions/C++\%Users\%denil.vim

I am not sure if this is the best way to fix this. We could simplify the logic to only check` IS_WIN32` once.

Tested on Linux (WSL2) and Windows

Thank you.