### PR TITLE
Handle case where there are no session files

### DIFF
--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -108,7 +108,6 @@ do
     local latest_session = { session = nil, last_edited = 0 }
 
     for _, filename in ipairs(vim.fn.readdir(dir)) do
-
       local session = AutoSession.conf.auto_session_root_dir..filename
       local last_edited = vim.fn.getftime(session)
 
@@ -118,8 +117,12 @@ do
       end
     end
 
-    -- Need to escape % chars on the filename so expansion doesn't happen
-    return latest_session.session:gsub("%%", "\\%%")
+    if (latest_session.session ~= nil) then
+      -- Need to escape % chars on the filename so expansion doesn't happen
+      return latest_session.session:gsub("%%", "\\%%")
+    else
+      return nil
+    end
   end
 end
 
@@ -246,8 +249,10 @@ function AutoSession.RestoreSession(sessions_dir_or_file)
     else
       if AutoSession.conf.auto_session_enable_last_session then
         local last_session_file_path = AutoSession.get_latest_session()
-        Lib.logger.info("Restoring last session", last_session_file_path)
-        restore(last_session_file_path)
+        if (last_session_file_path ~= nil) then
+          Lib.logger.info("Restoring last session", last_session_file_path)
+          restore(last_session_file_path)
+        end
       else
         Lib.logger.debug("File not readable, not restoring session")
       end
@@ -270,12 +275,12 @@ local maybe_disable_autosave = function(session_name)
   local current_session = Lib.escaped_session_name_from_cwd()
   if session_name == current_session then
     Lib.logger.debug("Auto Save disabled for current session.", vim.inspect({
-      session_name = session_name, current_session = current_session 
+      session_name = session_name, current_session = current_session
     }))
     AutoSession.conf.auto_save_enabled = false
   else
     Lib.logger.debug("Auto Save is still enabled for current session.", vim.inspect({
-      session_name = session_name, current_session = current_session 
+      session_name = session_name, current_session = current_session
     }))
   end
 end


### PR DESCRIPTION
**Use case**:
**Neovim**: v0.5.0-dev+1411-gb28d458f8

auto-session configured as below:
``` lua
local opts = {
  auto_session_enable_last_session = true,
  auto_session_enabled = true,
  auto_session_root_dir = vim.fn.stdpath('data').."/sessions/",
  log_level = 'info',
  pre_save_cmds = {'lua G_cVim.fileExplorer.close()'}
}
```
No files in the `sessions` path.

Existing code finds no files.
https://github.com/rmagatti/auto-session/blob/main/lua/auto-session.lua#L110-L119
``` lua
    for _, filename in ipairs(vim.fn.readdir(dir)) do
      local session = AutoSession.conf.auto_session_root_dir..filename     
      local last_edited = vim.fn.getftime(session)
      if last_edited > latest_session.last_edited then
        latest_session.session = session
        latest_session.last_edited = last_edited
      end
    end
```
and as a result
https://github.com/rmagatti/auto-session/blob/main/lua/auto-session.lua#L122
``` lua
    return latest_session.session:gsub("%%", "\\%%")
```
fails because `latest_session.session` is nil.

PR handles this use case.