### PR TITLE
Keep track of last loaded session. Closes #45

### DIFF
--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -2,7 +2,8 @@ local Config = {}
 local Lib = {
   logger = {},
   conf = {
-    log_level = false
+    log_level = false,
+    last_loaded_session = nil
   },
   Config = Config,
   _VIM_FALSE = 0,
@@ -126,7 +127,7 @@ function Lib.escape_dir(dir)
 end
 
 function Lib.escaped_session_name_from_cwd()
-  return IS_WIN32 and Lib.unescape_dir(vim.fn.getcwd()) or Lib.escape_dir(vim.fn.getcwd()) 
+  return IS_WIN32 and Lib.unescape_dir(vim.fn.getcwd()) or Lib.escape_dir(vim.fn.getcwd())
 end
 
 local function get_win32_legacy_cwd(cwd)


### PR DESCRIPTION
This addresses #45 by keeping track in memory of the last loaded session and using that instead of trying to get from cwd on SessionSave.