### PR TITLE
Address a seemingly breaking scenario when opening a non-git directory

### DIFF
--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -95,7 +95,7 @@ local function get_branch_name()
   if AutoSession.conf.auto_session_use_git_branch then
     local out = vim.fn.systemlist('git rev-parse --abbrev-ref HEAD')
     if vim.v.shell_error ~= 0 then
-      vim.api.nvim_err_writeln(string.format("git failed with: %s", table.concat(out, "\n")))
+      Lib.logger.debug(string.format("git failed with: %s", table.concat(out, "\n")))
       return ""
     end
     return out[1]


### PR DESCRIPTION
The session was still created correctly and everything works but the way
the error is presented makes it seem like the plugin just broke, making
it a debug log instead to make using git and non-git directories more
seamless.

Closes #131 