### PR TITLE
feat(commands): add Autosession commands using ui.select

### DIFF
--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -321,6 +321,7 @@ end
 local function open_picker(files, prompt, callback)
   vim.ui.select(files, {
     prompt = prompt,
+    kind = "auto-session",
     format_item = function(item)
       return item.display_name
     end,

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -301,7 +301,7 @@ local function format_file_name(path)
 end
 
 ---@return PickerItem[]
-local function get_session_files()
+function AutoSession.get_session_files()
   local files = {}
   local sessions_dir = AutoSession.get_root_dir()
   if not vim.fn.isdirectory(sessions_dir) then
@@ -333,7 +333,7 @@ end
 
 ---@param data table
 local function handle_autosession_command(data)
-  local files = get_session_files()
+  local files = AutoSession.get_session_files()
   if data.args:match "search" then
     open_picker(files, "Select a session to select:", function(choice)
       AutoSession.AutoSaveSession()


### PR DESCRIPTION
This PR implements my suggestion in #140, although frankly I should have waited to get your take first 😅. Was just pretty keen on it. Anyway, the changes include adding an `Autosession` command using the `vim.api.nvim_create_user_command`. This command can be expanded in the future but for now it takes two arguments `Autosession delete` or `Autosession search` both will use `vim.ui.select` to open the picker a user has configured e.g. Telescope or FZF or some custom function.

On confirming a selection it will restore or delete the session ~(*eventually*) for now, when I try and restore the session it doesn't work. I don't know if the path I'm using is incorrect for the session or what the right argument looks like~