### PR TITLE
Add support for usage of base paths with wildcard for suppress_dirs and allowed_dirs properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ require('lualine').setup{
 | auto_session_allowed_dirs         | ["list", "of paths"]          | nil                                   | Allow session create/restore if in one of the list of dirs             |
 | auto_session_use_git_branch       | false, true, nil              | nil                                   | Use the git branch to differentiate the session name                   |
 
+`auto_session_suppress_dirs` and `auto_session_allowed_dirs` support base paths with `*` wildcard (e.g.: `/my/base/path/*`)
+
 ### Lua Only Options
 | Config                            | Options                       | Default                               | Description                                                            |
 | --------------------------------- | -------------------------     | ------------------------------------- | ----------------------------------------------------------------       |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ require('lualine').setup{
 | auto_session_allowed_dirs         | ["list", "of paths"]          | nil                                   | Allow session create/restore if in one of the list of dirs             |
 | auto_session_use_git_branch       | false, true, nil              | nil                                   | Use the git branch to differentiate the session name                   |
 
+#### Notes
 `auto_session_suppress_dirs` and `auto_session_allowed_dirs` support base paths with `*` wildcard (e.g.: `/my/base/path/*`)
 
 ### Lua Only Options

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -172,7 +172,7 @@ local function suppress_session()
   local cwd = vim.fn.getcwd()
   for _, s in pairs(dirs) do
     s = string.gsub(vim.fn.simplify(vim.fn.expand(s)), "/+$", "")
-    if cwd == s then
+    if string.find(s, cwd, 1, true) ~= nil then
       return true
     end
   end
@@ -188,7 +188,7 @@ local function is_allowed_dir()
   local cwd = vim.fn.getcwd()
   for _, s in pairs(dirs) do
     s = string.gsub(vim.fn.simplify(vim.fn.expand(s)), "/+$", "")
-    if cwd == s then
+    if string.find(s, cwd, 1, true) ~= nil then
       Lib.logger.debug("is_allowed_dir", true)
       return true
     end


### PR DESCRIPTION
The idea came up because I have all my workspaces which I'd want to create sessions for in the same base folder.
So instead of specifying one by one, I wanted to just set the base path.

Using the `*` wildcard at the end of the path makes `vim.fn.simplify(vim.fn.expand(s))` return a string containing all the directories inside the base path. Then Lua's `string.find` returns a non-nil value if `s` contains `cwd`, thus producing a match, making suppressing or allowing everything under a base path easier.