### PR TITLE
feat: disable in headless mode

### DIFF
--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -118,8 +118,12 @@ local in_pager_mode = function()
   return pager_mode
 end
 
+local in_headless_mode = function()
+  return not next(vim.api.nvim_list_uis())
+end
+
 local auto_save = function()
-  if in_pager_mode() then
+  if in_pager_mode() or in_headless_mode() then
     return false
   end
 
@@ -133,7 +137,7 @@ local auto_save = function()
 end
 
 local auto_restore = function()
-  if in_pager_mode() then
+  if in_pager_mode() or in_headless_mode() then
     return false
   end
 
@@ -472,16 +476,8 @@ end
 
 local maybe_disable_autosave = function(session_name)
   local current_session = Lib.escaped_session_name_from_cwd()
-  if not next(vim.api.nvim_list_uis()) then
-    Lib.logger.debug(
-      "Auto Save disabled in headless mode.",
-      vim.inspect {
-        session_name = session_name,
-        current_session = current_session,
-      }
-    )
-    AutoSession.conf.auto_save_enabled = false
-  elseif session_name == current_session then
+
+  if session_name == current_session then
     Lib.logger.debug(
       "Auto Save disabled for current session.",
       vim.inspect {

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -307,10 +307,10 @@ function AutoSession.get_session_files()
   if not vim.fn.isdirectory(sessions_dir) then
     return files
   end
-  local entries =  vim.fn.readdir(sessions_dir, function (item)
+  local entries = vim.fn.readdir(sessions_dir, function(item)
     return vim.fn.isdirectory(item) == 0
   end)
-  return vim.tbl_map(function (entry)
+  return vim.tbl_map(function(entry)
     return { display_name = format_file_name(entry), path = entry }
   end, entries)
 end
@@ -472,7 +472,16 @@ end
 
 local maybe_disable_autosave = function(session_name)
   local current_session = Lib.escaped_session_name_from_cwd()
-  if session_name == current_session then
+  if not next(vim.api.nvim_list_uis()) then
+    Lib.logger.debug(
+      "Auto Save disabled in headless mode.",
+      vim.inspect {
+        session_name = session_name,
+        current_session = current_session,
+      }
+    )
+    AutoSession.conf.auto_save_enabled = false
+  elseif session_name == current_session then
     Lib.logger.debug(
       "Auto Save disabled for current session.",
       vim.inspect {


### PR DESCRIPTION
Sometimes I run things like

```
nvim --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'
```

and I noticed I get the auto-session logs.

IMHO, auto-session should be skipped when run in headless mode.

Let me know what you think :)

PS: my first pr with lua code ever :) 