### PR TITLE
fix(allowed_supress): use string.gmatch instead of string.find

### DIFF
--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -172,10 +172,13 @@ local function suppress_session()
   local cwd = vim.fn.getcwd()
   for _, s in pairs(dirs) do
     s = string.gsub(vim.fn.simplify(Lib.expand(s)), "/+$", "")
-    if string.find(s, cwd, 1, true) ~= nil then
-      return true
+    for path in string.gmatch(s, "[^\r\n]+") do
+      if cwd == path then
+        return true
+      end
     end
   end
+
   return false
 end
 
@@ -188,9 +191,11 @@ local function is_allowed_dir()
   local cwd = vim.fn.getcwd()
   for _, s in pairs(dirs) do
     s = string.gsub(vim.fn.simplify(Lib.expand(s)), "/+$", "")
-    if string.find(s, cwd, 1, true) ~= nil then
-      Lib.logger.debug("is_allowed_dir", true)
-      return true
+    for path in string.gmatch(s, "[^\r\n]+") do
+      if cwd == path then
+        Lib.logger.debug("is_allowed_dir", true)
+        return true
+      end
     end
   end
 


### PR DESCRIPTION
I found out, during normal usage, that `string.find` was also matching for "root" directories of a specified path.

E.g.: 
`auto_session_allowed_dirs` = { "/my/path/to/repo" }

If I open `vim` in `/my/path` and quit, a session is created for that directory too (since `/my/path` is also contained in the specified directory.


`string.gmatch` will split the string by line breaks and generate an iterator. The difference between this and what we had before the `string.find` usage is that this still supports the paths with wildcards, but it's gonna check each one for equality with `cwd` and will only match for fully qualified paths, instead of partial ones.