### PR TITLE
Add DirChangedPre and DirChanged handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # 🗒️ Description
+
 Auto Session takes advantage of Neovim's existing session management capabilities to provide seamless automatic session management.
 
 <img src="https://github.com/rmagatti/readme-assets/blob/main/auto-session-zoomed.gif" width="1000" />
 
 # 💡 Behaviour
+
 1. When starting `nvim` with no arguments, auto-session will try to restore an existing session for the current `cwd` if one exists.
 2. When starting `nvim .` with some argument, auto-session will do nothing.
 3. Even after starting `nvim` with an argument, a session can still be manually restored by running `:RestoreSession`.
@@ -13,16 +15,32 @@ Auto Session takes advantage of Neovim's existing session management capabilitie
 :warning: Please note that if there are errors in your config, restoring the session might fail, if that happens, auto session will then disable auto saving for the current session.
 Manually saving a session can still be done by calling `:SaveSession`.
 
+AutoSession now tracks `cwd` changes!
+By default, handling is as follows:
+  DirChangedPre (before the cwd actually changes):
+    - Save the current session
+    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the
+      next session.
+    - Clear jumps. Also done so there is no bleading between sessions.
+    - Run the `pre_cwd_changed_hook`
+  DirChanged (after the cwd has changed):
+    - Restore session using new cwd
+    - Run the `post_cwd_changed_hook`
+    
+Now when the user changes the cwd with `:cd some/new/dir` auto-session handles it gracefully, saving the current session so there aren't losses and loading the session for the upcoming cwd if it exists.
+
+
 # 📦 Installation
+
 Any plugin manager should do, I use [Packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua
 use {
   'rmagatti/auto-session',
   config = function()
-    require('auto-session').setup {
-      log_level = 'info',
-      auto_session_suppress_dirs = {'~/', '~/Projects'}
+    require("auto-session").setup {
+      log_level = "error",
+      auto_session_suppress_dirs = { "~/", "~/Projects", "~/Downloads", "/"},
     }
   end
 }
@@ -31,10 +49,13 @@ use {
 # ⚙️ Configuration
 
 ### Default
-Auto Session by default stores sessions in `vim.fn.stdpath('data').."/sessions/"`.  
+
+Auto Session by default stores sessions in `vim.fn.stdpath('data').."/sessions/"`.
 
 ### Custom
-One can set the auto\_session root dir that will be used for auto session saving and restoring.
+
+One can set the auto_session root dir that will be used for auto session saving and restoring.
+
 ```viml
 let g:auto_session_root_dir = path/to/my/custom/dir
 
@@ -58,9 +79,11 @@ EOF
 ```
 
 ### Statusline
+
 One can show the current session name in the statusline by using an auto-session helper function.
 
 Lualine example config and how it looks
+
 ```lua
 require('lualine').setup{
   options = {
@@ -69,27 +92,30 @@ require('lualine').setup{
   sections = {lualine_c = {require('auto-session-library').current_session_name}}
 }
 ```
+
 <img width="1904" alt="Screen Shot 2021-10-30 at 3 58 57 PM" src="https://user-images.githubusercontent.com/2881382/139559478-8edefdb8-8254-42e7-a0f3-babd3dfd6ff2.png">
 
-
 ### Options
-| Config                            | Options                       | Default                               | Description                                                            |
-| --------------------------------- | -------------------------     | ------------------------------------- | ----------------------------------------------------------------       |
-| log_level                         | 'debug', 'info', 'error'      | 'info'                                | Sets the log level of the plugin                                       |
-| auto_session_enable_last_session  | false, true                   | false                                 | Loads the last loaded session if session for cwd does not exist        |
-| auto_session_root_dir             | "/some/path/you/want"         | vim.fn.stdpath('data').."/sessions/"  | Changes the root dir for sessions                                      |
-| auto_session_enabled              | false, true                   | true                                  | Enables/disables the plugin's auto save _and_ restore features         |
-| auto_session_create_enabled       | false, true                   | true                                  | Enables/disables the plugin's session auto creation                    |
-| auto_save_enabled                 | false, true, nil              | nil                                   | Enables/disables auto saving                                           |
-| auto_restore_enabled              | false, true, nil              | nil                                   | Enables/disables auto restoring                                        |
-| auto_session_suppress_dirs        | ["list", "of paths"]          | nil                                   | Suppress session create/restore if in one of the list of dirs          |
-| auto_session_allowed_dirs         | ["list", "of paths"]          | nil                                   | Allow session create/restore if in one of the list of dirs             |
-| auto_session_use_git_branch       | false, true, nil              | nil                                   | Use the git branch to differentiate the session name                   |
+
+| Config                           | Options                  | Default                              | Description                                                     |
+| -------------------------------- | ------------------------ | ------------------------------------ | --------------------------------------------------------------- |
+| log_level                        | 'debug', 'info', 'error' | 'info'                               | Sets the log level of the plugin                                |
+| auto_session_enable_last_session | false, true              | false                                | Loads the last loaded session if session for cwd does not exist |
+| auto_session_root_dir            | "/some/path/you/want"    | vim.fn.stdpath('data').."/sessions/" | Changes the root dir for sessions                               |
+| auto_session_enabled             | false, true              | true                                 | Enables/disables the plugin's auto save _and_ restore features  |
+| auto_session_create_enabled      | false, true              | true                                 | Enables/disables the plugin's session auto creation             |
+| auto_save_enabled                | false, true, nil         | nil                                  | Enables/disables auto saving                                    |
+| auto_restore_enabled             | false, true, nil         | nil                                  | Enables/disables auto restoring                                 |
+| auto_session_suppress_dirs       | ["list", "of paths"]     | nil                                  | Suppress session create/restore if in one of the list of dirs   |
+| auto_session_allowed_dirs        | ["list", "of paths"]     | nil                                  | Allow session create/restore if in one of the list of dirs      |
+| auto_session_use_git_branch      | false, true, nil         | nil                                  | Use the git branch to differentiate the session name            |
 
 #### Notes
+
 `auto_session_suppress_dirs` and `auto_session_allowed_dirs` support base paths with `*` wildcard (e.g.: `/my/base/path/*`)
 
 ### Lua Only Options
+
 ```lua
 require("auto-session").setup {
   bypass_session_save_file_types = nil, -- boolean: Bypass auto save when only buffer open is one of these file types
@@ -102,14 +128,17 @@ require("auto-session").setup {
 ```
 
 #### Recommended sessionoptions config
+
 For a better experience with the plugin overall using this config for `sessionoptions` is recommended.
 
 **Lua**
+
 ```lua
 vim.o.sessionoptions="blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal"
 ```
 
 **VimL**
+
 ```viml
 set sessionoptions+=winpos,terminal,folds
 ```
@@ -117,10 +146,12 @@ set sessionoptions+=winpos,terminal,folds
 :warning: if you use [packer.nvim](https://github.com/wbthomason/packer.nvim)'s lazy loading feature, and you have the `options` value in your `sessionoptions` beware it might lead to weird behaviour with the lazy loading, especially around key-based lazy loading where keymaps are kept and thus the lazy loading mapping packer creates never gets set again.
 
 ### Last Session
+
 This optional feature enables the keeping track and loading of the last session.
 This loading of a last session happens only when a `RestoreSession` could not find a session for the current dir.
 This feature can come in handy when starting Neovim from a GUI for example.
 :warning: This feature is still experimental and as of right now it interferes with the plugin's ability to auto create new sessions when opening Neovim in a new directory.
+
 ```lua
 require('auto-session').setup {
     auto_session_enable_last_session=true,
@@ -130,7 +161,9 @@ require('auto-session').setup {
 :warning: WARNING :warning: If the directory does not exist, default directory will be used and an error message will be printed.
 
 # 📢 Commands
+
 Auto Session exposes two commands that can be used or mapped to any keybindings for manually saving and restoring sessions.
+
 ```viml
 :SaveSession " saves or creates a session in the currently set `auto_session_root_dir`.
 :SaveSession ~/my/custom/path " saves or creates a session in the specified directory path.
@@ -146,17 +179,20 @@ Auto Session exposes two commands that can be used or mapped to any keybindings 
 You can use the `Autosession {delete|search}` command to open a picker using `vim.ui.select` this will allow you to either delete or search for a session to restore.
 
 ## 🪝 Command Hooks
+
 #### Command hooks are a list of commands that get executed at different stages of the session management lifecycle.
 
-Command hooks exist in the format: {hook\_name}
-- {pre\_save}: executes _before_ a session is saved
-- {post\_save}: executes _after_ a session is saved
-- {pre\_restore}: executs _before_ a session is restored
-- {post\_restore}: executs _after_ a session is restored
-- {pre\_delete}: executs _before_ a session is deleted
-- {post\_delete}: executs _after_ a session is deleted
+Command hooks exist in the format: {hook_name}
+
+- {pre*save}: executes \_before* a session is saved
+- {post*save}: executes \_after* a session is saved
+- {pre*restore}: executs \_before* a session is restored
+- {post*restore}: executs \_after* a session is restored
+- {pre*delete}: executs \_before* a session is deleted
+- {post*delete}: executs \_after* a session is deleted
 
 Hooks are configured by setting
+
 ```viml
 let g:auto_session_{hook_name}_cmds = ["{hook_command1}", "{hook_command2}"]
 
@@ -167,14 +203,17 @@ require('auto-session').setup {
 }
 EOF
 ```
+
 `hook_command` is a valid command mode command.
 e.g. to close NERDTree before saving the session.
+
 ```viml
 let g:auto_session_pre_save_cmds = ["tabdo NERDTreeClose"]
 ```
 
 Hooks can also be lua functions
 For example to update the directory of the session in nvim-tree:
+
 ```lua
 local function restore_nvim_tree()
     local nvim_tree = require('nvim-tree')
@@ -188,6 +227,7 @@ require('auto-session').setup {
 ```
 
 ## Disabling the plugin
+
 One might run into issues with Firenvim or another plugin and want to disable auto_session altogether based on some condition.
 For this example, as to not try and save sessions for Firenvim, we disable the plugin if the started_by_firenvim variable is set.
 
@@ -198,25 +238,31 @@ endif
 ```
 
 One can also disable the plugin by setting the `auto_session_enabled` option to false at startup.
+
 ```sh
 nvim "+let g:auto_session_enabled = v:false"
 ```
 
 ## 🚧 Troubleshooting
+
 For troubleshooting refer to the [wiki page](https://github.com/rmagatti/auto-session/wiki/Troubleshooting)
 
 ## 🔭 Session Lens
+
 [Session Lens](https://github.com/rmagatti/session-lens) is a companion plugin to auto-session built on top of [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) for easy switching between existing sessions.
 
 See installation and usage instructions in the plugin's page.
 
 ### Preview
+
 <img src="https://github.com/rmagatti/readme-assets/blob/main/session-lens.gif" width=1000 />
 
 # Compatibility
+
 Neovim > 0.5
 
 Tested with:
+
 ```
 NVIM v0.5.0-dev+a1ec36f
 Build type: Release

--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ require('lualine').setup{
 `auto_session_suppress_dirs` and `auto_session_allowed_dirs` support base paths with `*` wildcard (e.g.: `/my/base/path/*`)
 
 ### Lua Only Options
-| Config                            | Options                       | Default                               | Description                                                            |
-| --------------------------------- | -------------------------     | ------------------------------------- | ----------------------------------------------------------------       |
-| bypass_session_save_file_types    | ["list", "of filetype names"] | nil                                   | Bypass session save if _only_ buffer open is of one of these filetypes |
+```lua
+require("auto-session").setup {
+  bypass_session_save_file_types = nil, -- boolean: Bypass auto save when only buffer open is one of these file types
+  cwd_change_handling = { -- table: Config for handling the DirChangePre and DirChanged autocmds, can be set to nil to disable altogether
+    restore_upcoming_session = true, -- boolean: restore session for upcoming cwd on cwd change
+    pre_cwd_changed_hook = nil, -- function: This is called after auto_session code runs for the `DirChangedPre` autocmd
+    post_cwd_changed_hook = nil, -- function: This is called after auto_session code runs for the `DirChanged` autocmd
+  },
+}
+```
 
 #### Recommended sessionoptions config
 For a better experience with the plugin overall using this config for `sessionoptions` is recommended.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ By default, handling is as follows:
     
 Now when the user changes the cwd with `:cd some/new/dir` auto-session handles it gracefully, saving the current session so there aren't losses and loading the session for the upcoming cwd if it exists.
 
+Hooks are available for custom actions _before_ and _after_ the `cwd` is changed. These hooks can be configured through the `cwd_change_handling` key as follows:
+```lua
+require("auto-session").setup {
+  log_level = "error",
+
+  cwd_change_handling = {
+    restore_upcoming_session = true, -- already the default, no need to specify like this, only here as an example
+    pre_cwd_changed_hook = nil, -- already the default, no need to specify like this, only here as an example
+    post_cwd_changed_hook = function() -- example refreshing the lualine status line _after_ the cwd changes
+      require("lualine").refresh() -- refresh lualine so the new session name is displayed in the status bar
+    end,
+  },
+}
+
+```
+
 
 # 📦 Installation
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,20 @@
-Lua                                                                        *Lua*
-    Only Configs for Auto Session 
+defaultLuaConf                                                  *defaultLuaConf*
+    table default config for auto session
+
+    Fields: ~
+        {log_level}                         (string)       debug, info, error
+        {auto_session_enable_last_session}  (boolean)
+        {auto_session_root_dir}             (string)       root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
+        {auto_session_enabled}              (boolean)      enable auto session
+        {auto_session_create_enabled}       (boolean|nil)  Enables/disables auto creating new sessions
+        {auto_save_enabled}                 (boolean|nil)  Enables/disables auto saving session
+        {auto_restore_enabled}              (boolean|nil)  Enables/disables auto restoring session
+        {auto_session_allowed_dirs}         (table|nil)    Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
+        {auto_session_use_git_branch}       (boolean|nil)  Include git branch name in session name to differentiate between sessions for different git branches
+
+
+luaOnlyConf                                                        *luaOnlyConf*
+    Lua Only Configs for Auto Session
 
     Fields: ~
         {bypass_session_save_file_types}  (string?)  Bypass auto save when only buffer open is one of these file types
@@ -14,8 +29,11 @@ CwdChangeHandling                                            *CwdChangeHandling*
         {post_cwd_changed_hook}     (boolean?)  {true} This is called after auto_session code runs for the `DirChanged` autocmd
 
 
-AutoSession.setup()                                          *AutoSession.setup*
+AutoSession.setup({config})                                  *AutoSession.setup*
+    Setup function for AutoSession
 
+    Parameters: ~
+        {config}  (table|nil)  config for auto session
 
 
 AutoSession.get_latest_session()                *AutoSession.get_latest_session*
@@ -78,11 +96,13 @@ AutoSession.get_session_files()                  *AutoSession.get_session_files*
         {PickerItem[]}
 
 
-AutoSession.SaveSession({sessions_dir})                *AutoSession.SaveSession*
+                                                       *AutoSession.SaveSession*
+AutoSession.SaveSession({sessions_dir}, {auto})
 
 
     Parameters: ~
-        {sessions_dir}  (string?)  ---@param auto boolean
+        {sessions_dir}  (string?)
+        {auto}          (boolean)
 
 
                                                 *AutoSession.AutoRestoreSession*
@@ -133,14 +153,14 @@ AutoSession.DeleteSessionByName({...})         *AutoSession.DeleteSessionByName*
     DeleteSessionByName deletes sessions given a provided list of paths
 
     Parameters: ~
-        {...}  (unknown)
+        {...}  (string[])
 
 
 AutoSession.DeleteSession({...})                     *AutoSession.DeleteSession*
     DeleteSession delets a single session given a provided path
 
     Parameters: ~
-        {...}  (unknown)
+        {...}  (string[])
 
 
                                                               *M.setup_autocmds*

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,0 +1,155 @@
+Lua                                                                        *Lua*
+    Only Configs for Auto Session 
+
+    Fields: ~
+        {bypass_session_save_file_types}  (string?)  Bypass auto save when only buffer open is one of these file types
+
+
+CwdChangeHandling                                            *CwdChangeHandling*
+    CWD Change Handling Config
+
+    Fields: ~
+        {restore_upcoming_session}  (boolean)   {true} restore session for upcoming cwd on cwd change
+        {pre_cwd_changed_hook}      (boolean?)  {true} This is called after auto_session code runs for the `DirChangedPre` autocmd
+        {post_cwd_changed_hook}     (boolean?)  {true} This is called after auto_session code runs for the `DirChanged` autocmd
+
+
+AutoSession.setup()                                          *AutoSession.setup*
+
+
+
+AutoSession.get_latest_session()                *AutoSession.get_latest_session*
+    Get latest session for the "last session" feature
+
+    Returns: ~
+        {string|nil}
+
+
+                                                   *AutoSession.AutoSaveSession*
+AutoSession.AutoSaveSession({sessions_dir})
+    AutoSaveSession
+    Function called by auto_session to trigger auto_saving sessions, for example on VimExit events.
+
+    Parameters: ~
+        {sessions_dir}  (string?)  the session directory to auto_save a session for. If empty this function will end up using the cwd to infer what session to save for.
+
+
+AutoSession.get_root_dir()                            *AutoSession.get_root_dir*
+    Gets the root directory of where to save the sessions.
+    By default this resolves to `vim.fn.stdpath "data" .. "/sessions/"`
+
+    Returns: ~
+        {string}
+
+
+AutoSession.get_cmds({typ})                               *AutoSession.get_cmds*
+    Get the hook commands to run
+    This function gets cmds from both lua and vimscript configs
+
+    Parameters: ~
+        {typ}  (string)
+
+    Returns: ~
+        {function[]|string[]}
+
+
+PickerItem                                                          *PickerItem*
+
+
+    Fields: ~
+        {display_name}  (string)
+        {path}          (string)
+
+
+AutoSession.format_file_name({path})              *AutoSession.format_file_name*
+     Formats an autosession file name to be more presentable to a user
+
+    Parameters: ~
+        {path}  (string)
+
+    Returns: ~
+        {string}
+
+
+AutoSession.get_session_files()                  *AutoSession.get_session_files*
+
+
+    Returns: ~
+        {PickerItem[]}
+
+
+AutoSession.SaveSession({sessions_dir})                *AutoSession.SaveSession*
+
+
+    Parameters: ~
+        {sessions_dir}  (string?)  ---@param auto boolean
+
+
+                                                *AutoSession.AutoRestoreSession*
+AutoSession.AutoRestoreSession({sessions_dir})
+    Function called by AutoSession when automatically restoring a session.
+    This function avoids calling RestoreSession automatically when argv is not nil.
+
+    Parameters: ~
+        {sessions_dir}  (any)
+
+    Returns: ~
+        {boolean}  returns whether restoring the session was successful or not.
+
+
+                                            *AutoSession.RestoreSessionFromFile*
+AutoSession.RestoreSessionFromFile({session_file})
+    RestoreSessionFromFile takes a session_file and calls RestoreSession after parsing the provided parameter.
+
+    Parameters: ~
+        {session_file}  (string)
+
+
+                                                    *AutoSession.RestoreSession*
+AutoSession.RestoreSession({sessions_dir_or_file})
+    Restores the session by sourcing the session file if it exists/is readable.
+    This function is intended to be called by the user but it is also called by `AutoRestoreSession`
+
+    Parameters: ~
+        {sessions_dir_or_file}  (string)  a dir string or a file string
+
+    Returns: ~
+        {boolean}  returns whether restoring the session was successful or not.
+
+
+AutoSession.DisableAutoSave()                      *AutoSession.DisableAutoSave*
+    DisableAutoSave
+    Intended to be called by the user
+
+
+AutoSession.CompleteSessions()                    *AutoSession.CompleteSessions*
+    CompleteSessions is used by the vimscript command for session name/path completion.
+
+    Returns: ~
+        {string}
+
+
+AutoSession.DeleteSessionByName({...})         *AutoSession.DeleteSessionByName*
+    DeleteSessionByName deletes sessions given a provided list of paths
+
+    Parameters: ~
+        {...}  (unknown)
+
+
+AutoSession.DeleteSession({...})                     *AutoSession.DeleteSession*
+    DeleteSession delets a single session given a provided path
+
+    Parameters: ~
+        {...}  (unknown)
+
+
+                                                              *M.setup_autocmds*
+M.setup_autocmds({config}, {AutoSession})
+    Setup autocmds for DirChangedPre and DirChanged
+
+    Parameters: ~
+        {config}       (table)  auto session config
+        {AutoSession}  (table)  auto session instance
+
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,4 @@
-defaultLuaConf                                                  *defaultLuaConf*
+defaultConf                                                        *defaultConf*
     table default config for auto session
 
     Fields: ~
@@ -17,7 +17,8 @@ luaOnlyConf                                                        *luaOnlyConf*
     Lua Only Configs for Auto Session
 
     Fields: ~
-        {bypass_session_save_file_types}  (string?)  Bypass auto save when only buffer open is one of these file types
+        {bypass_session_save_file_types}  (string?)            Bypass auto save when only buffer open is one of these file types
+        {cwd_change_handling}             (CwdChangeHandling)
 
 
 CwdChangeHandling                                            *CwdChangeHandling*
@@ -33,7 +34,7 @@ AutoSession.setup({config})                                  *AutoSession.setup*
     Setup function for AutoSession
 
     Parameters: ~
-        {config}  (table|nil)  config for auto session
+        {config}  (defaultConf)  config for auto session
 
 
 AutoSession.get_latest_session()                *AutoSession.get_latest_session*

--- a/lua/auto-session-autocmds.lua
+++ b/lua/auto-session-autocmds.lua
@@ -2,6 +2,9 @@ local Lib = require "auto-session-library"
 
 local M = {}
 
+---Setup autocmds for DirChangedPre and DirChanged
+---@param config table auto session config
+---@param AutoSession table auto session instance
 M.setup_autocmds = function(config, AutoSession)
   if vim.tbl_isempty(config.cwd_change_handling) or config.cwd_change_handling == nil then
     return

--- a/lua/auto-session-autocmds.lua
+++ b/lua/auto-session-autocmds.lua
@@ -1,0 +1,54 @@
+local Lib = require "auto-session-library"
+
+local M = {}
+
+M.setup_autocmds = function(config, AutoSession)
+  if vim.tbl_isempty(config.cwd_change_handling) or config.cwd_change_handling == nil then
+    return
+  end
+
+  local conf = config.cwd_change_handling
+
+  vim.api.nvim_create_autocmd("DirChangedPre", {
+    callback = function()
+      Lib.logger.debug "DirChangedPre"
+      Lib.logger.debug("cwd: " .. vim.fn.getcwd())
+
+      AutoSession.AutoSaveSession()
+
+      -- Clear all buffers and jumps after session save so session doesn't blead over to next session.
+      vim.cmd "%bd!"
+      vim.cmd "clearjumps"
+
+      if type(conf.pre_cwd_changed_hook) == "function" then
+        conf.pre_cwd_changed_hook()
+      end
+    end,
+    pattern = "global",
+  })
+
+  if conf.restore_upcoming_session then
+    vim.api.nvim_create_autocmd("DirChanged", {
+      callback = function()
+        Lib.logger.debug "DirChanged"
+        Lib.logger.debug("cwd: " .. vim.fn.getcwd())
+
+        -- Deferring to avoid otherwise there are tresitter highlighting issues
+        vim.defer_fn(function()
+          local success = AutoSession.AutoRestoreSession()
+
+          if not success then
+            Lib.logger.info("Could not load session. A session file is likely missing for this cwd." .. vim.fn.getcwd())
+          end
+
+          if type(conf.post_cwd_changed_hook) == "function" then
+            conf.post_cwd_changed_hook()
+          end
+        end, 50)
+      end,
+      pattern = "global",
+    })
+  end
+end
+
+return M

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -28,6 +28,7 @@ function Config.normalize(config, existing)
 
   return conf
 end
+
 -- ====================================================
 
 -- Helper functions ===============================================================
@@ -188,20 +189,21 @@ end
 -- Logger =========================================================
 function Lib.logger.debug(...)
   if Lib.conf.log_level == "debug" then
-    print('debug', ...)
+    print("debug", ...)
   end
 end
 
 function Lib.logger.info(...)
   local valid_values = { "info", "debug" }
   if has_value(valid_values, Lib.conf.log_level) then
-    print('info', ...)
+    print("info", ...)
   end
 end
 
 function Lib.logger.error(...)
   error(...)
 end
+
 -- =========================================================
 
 return Lib

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -44,7 +44,7 @@ function Lib.is_empty(s)
 end
 
 function Lib.ends_with(str, ending)
-  return ending == "" or str:sub(- #ending) == ending
+  return ending == "" or str:sub(-#ending) == ending
 end
 
 function Lib.append_slash(str)
@@ -68,8 +68,8 @@ function Lib.validate_root_dir(root_dir)
   if vim.fn.isdirectory(Lib.expand(root_dir)) == Lib._VIM_FALSE then
     vim.cmd(
       "echoerr 'Invalid g:auto_session_root_dir. "
-      .. "Path does not exist or is not a directory. "
-      .. string.format("Defaulting to %s.", Lib.ROOT_DIR)
+        .. "Path does not exist or is not a directory. "
+        .. string.format("Defaulting to %s.", Lib.ROOT_DIR)
     )
     return Lib.ROOT_DIR
   else

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -11,35 +11,8 @@ local Lib = {
   ROOT_DIR = nil,
 }
 
--- Setup ======================================================
 function Lib.setup(config)
-  Lib.conf = Config.normalize(config)
-end
-
-function Config.normalize(config, existing)
-  local conf = existing or {}
-  if Lib.is_empty_table(config) then
-    return conf
-  end
-
-  for k, v in pairs(config) do
-    conf[k] = v
-  end
-
-  return conf
-end
-
--- ====================================================
-
--- Helper functions ===============================================================
-local function has_value(tab, val)
-  for _, value in ipairs(tab) do
-    if value == val then
-      return true
-    end
-  end
-
-  return false
+  Lib.conf = vim.tbl_deep_extend("force", Lib.conf, config or {})
 end
 
 function Lib.get_file_name(url)
@@ -71,7 +44,7 @@ function Lib.is_empty(s)
 end
 
 function Lib.ends_with(str, ending)
-  return ending == "" or str:sub(-#ending) == ending
+  return ending == "" or str:sub(- #ending) == ending
 end
 
 function Lib.append_slash(str)
@@ -95,8 +68,8 @@ function Lib.validate_root_dir(root_dir)
   if vim.fn.isdirectory(Lib.expand(root_dir)) == Lib._VIM_FALSE then
     vim.cmd(
       "echoerr 'Invalid g:auto_session_root_dir. "
-        .. "Path does not exist or is not a directory. "
-        .. string.format("Defaulting to %s.", Lib.ROOT_DIR)
+      .. "Path does not exist or is not a directory. "
+      .. string.format("Defaulting to %s.", Lib.ROOT_DIR)
     )
     return Lib.ROOT_DIR
   else
@@ -179,14 +152,12 @@ end
 function Lib.expand(file_or_dir)
   local saved_wildignore = vim.api.nvim_get_option "wildignore"
   vim.api.nvim_set_option("wildignore", "")
-  local ret = vim.fn.expand(file_or_dir)
+  ---@diagnostic disable-next-line: param-type-mismatch
+  local ret = vim.fn.expand(file_or_dir, nil, nil)
   vim.api.nvim_set_option("wildignore", saved_wildignore)
   return ret
 end
 
--- ===================================================================================
-
--- Logger =========================================================
 function Lib.logger.debug(...)
   if Lib.conf.log_level == "debug" then
     print("debug", ...)
@@ -195,7 +166,7 @@ end
 
 function Lib.logger.info(...)
   local valid_values = { "info", "debug" }
-  if has_value(valid_values, Lib.conf.log_level) then
+  if vim.tbl_contains(valid_values, Lib.conf.log_level) then
     print("info", ...)
   end
 end
@@ -203,7 +174,5 @@ end
 function Lib.logger.error(...)
   error(...)
 end
-
--- =========================================================
 
 return Lib

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -26,7 +26,7 @@ local AutoSession = {
   conf = {},
 }
 
----@class defaultLuaConf table default config for auto session
+---@class defaultConf table default config for auto session
 ---@field log_level string debug, info, error
 ---@field auto_session_enable_last_session boolean
 ---@field auto_session_root_dir string root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
@@ -39,7 +39,7 @@ local AutoSession = {
 ---@field auto_session_use_git_branch boolean|nil Include git branch name in session name to differentiate between sessions for different git branches
 
 ---Default config for auto session
----@type defaultLuaConf
+---@type defaultConf 
 local defaultConf = {
   log_level = vim.g.auto_session_log_level or AutoSession.conf.logLevel or AutoSession.conf.log_level or "info", -- Sets the log level of the plugin (debug, info, error). camelCase logLevel for compatibility.
   auto_session_enable_last_session = vim.g.auto_session_enable_last_session or false, -- Enables/disables the "last session" feature
@@ -55,6 +55,7 @@ local defaultConf = {
 
 ---@class luaOnlyConf Lua Only Configs for Auto Session
 ---@field bypass_session_save_file_types string? Bypass auto save when only buffer open is one of these file types
+---@field cwd_change_handling CwdChangeHandling
 local luaOnlyConf = {
   bypass_session_save_file_types = nil, -- Bypass auto save when only buffer open is one of these file types
 
@@ -62,6 +63,8 @@ local luaOnlyConf = {
   ---@field restore_upcoming_session boolean {true} restore session for upcoming cwd on cwd change
   ---@field pre_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the `DirChangedPre` autocmd
   ---@field post_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the `DirChanged` autocmd
+
+  ---@type CwdChangeHandling
   cwd_change_handling = { -- Config for handling the DirChangePre and DirChanged autocmds, can be set to nil to disable altogether
     restore_upcoming_session = true,
     pre_cwd_changed_hook = nil, -- lua function hook. This is called after auto_session code runs for the `DirChangedPre` autocmd
@@ -76,10 +79,9 @@ AutoSession.conf = vim.tbl_extend("force", defaultConf, luaOnlyConf)
 Lib.conf = {
   log_level = AutoSession.conf.log_level,
 }
-Lib.ROOT_DIR = defaultConf.ROOT_DIR
 
 ---Setup function for AutoSession
----@param config table|nil config for auto session
+---@param config defaultConf config for auto session
 function AutoSession.setup(config)
   AutoSession.conf = Lib.Config.normalize(config, AutoSession.conf)
   Lib.ROOT_DIR = AutoSession.conf.auto_session_root_dir

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -39,7 +39,7 @@ local AutoSession = {
 ---@field auto_session_use_git_branch boolean|nil Include git branch name in session name to differentiate between sessions for different git branches
 
 ---Default config for auto session
----@type defaultConf 
+---@type defaultConf
 local defaultConf = {
   log_level = vim.g.auto_session_log_level or AutoSession.conf.logLevel or AutoSession.conf.log_level or "info", -- Sets the log level of the plugin (debug, info, error). camelCase logLevel for compatibility.
   auto_session_enable_last_session = vim.g.auto_session_enable_last_session or false, -- Enables/disables the "last session" feature
@@ -73,7 +73,7 @@ local luaOnlyConf = {
 }
 
 -- Set default config on plugin load
-AutoSession.conf = vim.tbl_extend("force", defaultConf, luaOnlyConf)
+AutoSession.conf = vim.tbl_deep_extend("force", defaultConf, luaOnlyConf)
 
 -- Pass configs to Lib
 Lib.conf = {
@@ -83,7 +83,7 @@ Lib.conf = {
 ---Setup function for AutoSession
 ---@param config defaultConf config for auto session
 function AutoSession.setup(config)
-  AutoSession.conf = Lib.Config.normalize(config, AutoSession.conf)
+  AutoSession.conf = vim.tbl_deep_extend("force", AutoSession.conf, config or {})
   Lib.ROOT_DIR = AutoSession.conf.auto_session_root_dir
   Lib.setup {
     log_level = AutoSession.conf.log_level,


### PR DESCRIPTION
This commit adds handling for when the cwd changes by setting callbacks
to both `DirChangedPre` and `DirChanged` autocmds.

Handling is as follows
  DirChangedPre:
    - Save the current session
    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the
      next session.
    - Clear jumps. Also done so there is no bleading between sessions.
    - Run the `pre_cwd_changed_hook`
  DirChanged:
    - Restore session using new cwd
    - Run the `post_cwd_changed_hook`

Now when the user changes the cwd with `:cd some/new/dir` auto-session
handles it gracefully, saving the current session so there aren't losses and loading the session for the upcoming cwd if it
exists.

Closes #102.