### PR TITLE
add feature for saving extra data to session

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ You can use the `Autosession {delete|search}` command to open a picker using `vi
 Command hooks exist in the format: {hook_name}
 
 - {pre*save}: executes \_before* a session is saved
+- {save*extra}: execute \_after* a session is saved, return string will save to `*x.vim`, reference `:help mks`
 - {post*save}: executes \_after* a session is saved
 - {pre*restore}: executs \_before* a session is restored
 - {post*restore}: executs \_after* a session is restored
@@ -216,6 +217,11 @@ let g:auto_session_{hook_name}_cmds = ["{hook_command1}", "{hook_command2}"]
 lua << EOF
 require('auto-session').setup {
     {hook_name}_cmds = {"{hook_command1}", "{hook_command2}"}
+    save_extra_cmds = {
+        function()
+            return [[echo "hello world"]]
+        end
+    }
 }
 EOF
 ```


### PR DESCRIPTION
# Related info
vim support to save additional setting, which file name `{session_file}x.vim` 

> :help mks

> If a file exists with the same name as the Session file, but ending in "x.vim" (for eXtra), executes that as well. You can use *x.vim files to
specify additional settings and actions associated with a given Session, such as creating menu items in the GUI version.

here is same pull request, I complete the feature base @nanozuki 's work Thanks♪(･ω･)ﾉ
https://github.com/rmagatti/auto-session/pull/89

# Feature

* new hook named `save_extra_cmds`
* filter out `x.vim` from `:Autosession search`

here is sample, when you restore session, neovim will load `{session_file}x.vim` automatically. for this case, echo 'hello world', when you restore session.
```lua
require('auto-session').setup {
    save_extra_cmds = {
        function()
            -- returned content will write to {session_file}x.vim
            return [[echo "hello world"]]
        end
    }
}
```

This is a appropriate time to save additional project/session configuration information, such as current nvim-dap launch