### PR TITLE
File tree integration with nvim-tree and NERDTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Auto Session takes advantage of Neovim's existing session management capabilitie
 :warning: Please note that if there are errors in your config, restoring the session might fail, if that happens, auto session will then disable auto saving for the current session.
 Manually saving a session can still be done by calling `:SaveSession`.
 
-AutoSession now tracks `cwd` changes!
-By default, handling is as follows:
-  DirChangedPre (before the cwd actually changes):
-    - Save the current session
-    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the
-      next session.
-    - Clear jumps. Also done so there is no bleading between sessions.
-    - Run the `pre_cwd_changed_hook`
-  DirChanged (after the cwd has changed):
-    - Restore session using new cwd
-    - Run the `post_cwd_changed_hook`
-
+AutoSession now tracks `cwd` changes!  
+By default, handling is as follows:  
+  DirChangedPre (before the cwd actually changes):  
+    - Save the current session  
+    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the  
+      next session.  
+    - Clear jumps. Also done so there is no bleading between sessions.  
+    - Run the `pre_cwd_changed_hook`  
+  DirChanged (after the cwd has changed):  
+    - Restore session using new cwd  
+    - Run the `post_cwd_changed_hook`  
+    
 Now when the user changes the cwd with `:cd some/new/dir` auto-session handles it gracefully, saving the current session so there aren't losses and loading the session for the upcoming cwd if it exists.
 
 Hooks are available for custom actions _before_ and _after_ the `cwd` is changed. These hooks can be configured through the `cwd_change_handling` key as follows:
@@ -113,19 +113,18 @@ require('lualine').setup{
 
 ### Options
 
-| Config                                    | Options                  | Default                              | Description                                                     |
-| ------------------------------------------| ------------------------ | ------------------------------------ | --------------------------------------------------------------- |
-| log_level                                 | 'debug', 'info', 'error' | 'info'                               | Sets the log level of the plugin                                |
-| auto_session_enable_last_session          | false, true              | false                                | Loads the last loaded session if session for cwd does not exist |
-| auto_session_enable_file_tree_integration | false, true              | false                                | Fixes problems with nvim-tree and NERDTree compatibility        |
-| auto_session_root_dir                     | "/some/path/you/want"    | vim.fn.stdpath('data').."/sessions/" | Changes the root dir for sessions                               |
-| auto_session_enabled                      | false, true              | true                                 | Enables/disables the plugin's auto save _and_ restore features  |
-| auto_session_create_enabled               | false, true              | true                                 | Enables/disables the plugin's session auto creation             |
-| auto_save_enabled                         | false, true, nil         | nil                                  | Enables/disables auto saving                                    |
-| auto_restore_enabled                      | false, true, nil         | nil                                  | Enables/disables auto restoring                                 |
-| auto_session_suppress_dirs                | ["list", "of paths"]     | nil                                  | Suppress session create/restore if in one of the list of dirs   |
-| auto_session_allowed_dirs                 | ["list", "of paths"]     | nil                                  | Allow session create/restore if in one of the list of dirs      |
-| auto_session_use_git_branch               | false, true, nil         | nil                                  | Use the git branch to differentiate the session name            |
+| Config                           | Options                  | Default                              | Description                                                     |
+| -------------------------------- | ------------------------ | ------------------------------------ | --------------------------------------------------------------- |
+| log_level                        | 'debug', 'info', 'error' | 'info'                               | Sets the log level of the plugin                                |
+| auto_session_enable_last_session | false, true              | false                                | Loads the last loaded session if session for cwd does not exist |
+| auto_session_root_dir            | "/some/path/you/want"    | vim.fn.stdpath('data').."/sessions/" | Changes the root dir for sessions                               |
+| auto_session_enabled             | false, true              | true                                 | Enables/disables the plugin's auto save _and_ restore features  |
+| auto_session_create_enabled      | false, true              | true                                 | Enables/disables the plugin's session auto creation             |
+| auto_save_enabled                | false, true, nil         | nil                                  | Enables/disables auto saving                                    |
+| auto_restore_enabled             | false, true, nil         | nil                                  | Enables/disables auto restoring                                 |
+| auto_session_suppress_dirs       | ["list", "of paths"]     | nil                                  | Suppress session create/restore if in one of the list of dirs   |
+| auto_session_allowed_dirs        | ["list", "of paths"]     | nil                                  | Allow session create/restore if in one of the list of dirs      |
+| auto_session_use_git_branch      | false, true, nil         | nil                                  | Use the git branch to differentiate the session name            |
 
 #### Notes
 
@@ -176,21 +175,6 @@ require('auto-session').setup {
 ```
 
 :warning: WARNING :warning: If the directory does not exist, default directory will be used and an error message will be printed.
-
-### File Tree Integration
-
-This fixes a lot of conflics with [`nvim-tree`](https://github.com/nvim-tree/nvim-tree.lua) and [`NERDTree`](https://github.com/preservim/nerdtree),
-as they both try to control the `cwd`, which causes infinite loops and corrupted session data.
-This feature synchronizes the `cwd` between `auto-session` and the file tree plugin, which turns out to be very powerful and fun to use.
-:warning: This feature is still experimental. Bugs to be expected.
-
-```lua
-require('auto-session').setup {
-    auto_session_enable_file_tree_integration=true,
-}
-```
-
-:warning: Note :warning: If you already have broken session data, this will not fix it. You will have to delete that session and start again
 
 # 📢 Commands
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Auto Session takes advantage of Neovim's existing session management capabilitie
 :warning: Please note that if there are errors in your config, restoring the session might fail, if that happens, auto session will then disable auto saving for the current session.
 Manually saving a session can still be done by calling `:SaveSession`.
 
-AutoSession now tracks `cwd` changes!  
-By default, handling is as follows:  
-  DirChangedPre (before the cwd actually changes):  
-    - Save the current session  
-    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the  
-      next session.  
-    - Clear jumps. Also done so there is no bleading between sessions.  
-    - Run the `pre_cwd_changed_hook`  
-  DirChanged (after the cwd has changed):  
-    - Restore session using new cwd  
-    - Run the `post_cwd_changed_hook`  
-    
+AutoSession now tracks `cwd` changes!
+By default, handling is as follows:
+  DirChangedPre (before the cwd actually changes):
+    - Save the current session
+    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the
+      next session.
+    - Clear jumps. Also done so there is no bleading between sessions.
+    - Run the `pre_cwd_changed_hook`
+  DirChanged (after the cwd has changed):
+    - Restore session using new cwd
+    - Run the `post_cwd_changed_hook`
+
 Now when the user changes the cwd with `:cd some/new/dir` auto-session handles it gracefully, saving the current session so there aren't losses and loading the session for the upcoming cwd if it exists.
 
 Hooks are available for custom actions _before_ and _after_ the `cwd` is changed. These hooks can be configured through the `cwd_change_handling` key as follows:
@@ -113,18 +113,19 @@ require('lualine').setup{
 
 ### Options
 
-| Config                           | Options                  | Default                              | Description                                                     |
-| -------------------------------- | ------------------------ | ------------------------------------ | --------------------------------------------------------------- |
-| log_level                        | 'debug', 'info', 'error' | 'info'                               | Sets the log level of the plugin                                |
-| auto_session_enable_last_session | false, true              | false                                | Loads the last loaded session if session for cwd does not exist |
-| auto_session_root_dir            | "/some/path/you/want"    | vim.fn.stdpath('data').."/sessions/" | Changes the root dir for sessions                               |
-| auto_session_enabled             | false, true              | true                                 | Enables/disables the plugin's auto save _and_ restore features  |
-| auto_session_create_enabled      | false, true              | true                                 | Enables/disables the plugin's session auto creation             |
-| auto_save_enabled                | false, true, nil         | nil                                  | Enables/disables auto saving                                    |
-| auto_restore_enabled             | false, true, nil         | nil                                  | Enables/disables auto restoring                                 |
-| auto_session_suppress_dirs       | ["list", "of paths"]     | nil                                  | Suppress session create/restore if in one of the list of dirs   |
-| auto_session_allowed_dirs        | ["list", "of paths"]     | nil                                  | Allow session create/restore if in one of the list of dirs      |
-| auto_session_use_git_branch      | false, true, nil         | nil                                  | Use the git branch to differentiate the session name            |
+| Config                                    | Options                  | Default                              | Description                                                     |
+| ------------------------------------------| ------------------------ | ------------------------------------ | --------------------------------------------------------------- |
+| log_level                                 | 'debug', 'info', 'error' | 'info'                               | Sets the log level of the plugin                                |
+| auto_session_enable_last_session          | false, true              | false                                | Loads the last loaded session if session for cwd does not exist |
+| auto_session_enable_file_tree_integration | false, true              | false                                | Fixes problems with nvim-tree and NERDTree compatibility        |
+| auto_session_root_dir                     | "/some/path/you/want"    | vim.fn.stdpath('data').."/sessions/" | Changes the root dir for sessions                               |
+| auto_session_enabled                      | false, true              | true                                 | Enables/disables the plugin's auto save _and_ restore features  |
+| auto_session_create_enabled               | false, true              | true                                 | Enables/disables the plugin's session auto creation             |
+| auto_save_enabled                         | false, true, nil         | nil                                  | Enables/disables auto saving                                    |
+| auto_restore_enabled                      | false, true, nil         | nil                                  | Enables/disables auto restoring                                 |
+| auto_session_suppress_dirs                | ["list", "of paths"]     | nil                                  | Suppress session create/restore if in one of the list of dirs   |
+| auto_session_allowed_dirs                 | ["list", "of paths"]     | nil                                  | Allow session create/restore if in one of the list of dirs      |
+| auto_session_use_git_branch               | false, true, nil         | nil                                  | Use the git branch to differentiate the session name            |
 
 #### Notes
 
@@ -175,6 +176,21 @@ require('auto-session').setup {
 ```
 
 :warning: WARNING :warning: If the directory does not exist, default directory will be used and an error message will be printed.
+
+### File Tree Integration
+
+This fixes a lot of conflics with [`nvim-tree`](https://github.com/nvim-tree/nvim-tree.lua) and [`NERDTree`](https://github.com/preservim/nerdtree),
+as they both try to control the `cwd`, which causes infinite loops and corrupted session data.
+This feature synchronizes the `cwd` between `auto-session` and the file tree plugin, which turns out to be very powerful and fun to use.
+:warning: This feature is still experimental. Bugs to be expected.
+
+```lua
+require('auto-session').setup {
+    auto_session_enable_file_tree_integration=true,
+}
+```
+
+:warning: Note :warning: If you already have broken session data, this will not fix it. You will have to delete that session and start again
 
 # 📢 Commands
 

--- a/lua/auto-session-autocmds.lua
+++ b/lua/auto-session-autocmds.lua
@@ -2,26 +2,6 @@ local Lib = require "auto-session-library"
 
 local M = {}
 
--- don't autorestore if there are open buffers (indicating auto save session failed)
-local function has_open_buffers()
-  local result = false
-  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if vim.fn.bufloaded(bufnr) then
-      local bufname = vim.api.nvim_buf_get_name(bufnr)
-      if bufname ~= "" then
-        if vim.fn.bufwinnr(bufnr) ~= -1 then
-          if result then
-            result = true
-            Lib.logger.debug("There are buffer(s) present: ")
-          end
-          Lib.logger.debug("  " .. bufname)
-        end
-      end
-    end
-  end
-  return result
-end
-
 ---Setup autocmds for DirChangedPre and DirChanged
 ---@param config table auto session config
 ---@param AutoSession table auto session instance
@@ -32,70 +12,67 @@ M.setup_autocmds = function(config, AutoSession)
   end
 
   local conf = config.cwd_change_handling
-  local scopes = { "global", "tabpage"}
 
-  for _, pattern in ipairs(scopes) do
-    vim.api.nvim_create_autocmd("DirChangedPre", {
-      callback = function()
-        Lib.logger.debug "DirChangedPre"
-        Lib.logger.debug("  cwd: " .. vim.fn.getcwd())
-        Lib.logger.debug("  target: " .. vim.v.event.directory)
-        Lib.logger.debug("  changed window: " .. tostring(vim.v.event.changed_window))
-        Lib.logger.debug("  scope: " .. vim.v.event.scope)
+  vim.api.nvim_create_autocmd("DirChangedPre", {
+    callback = function()
+      Lib.logger.debug "DirChangedPre"
+      Lib.logger.debug("  cwd: " .. vim.fn.getcwd())
+      Lib.logger.debug("  target: " .. vim.v.event.directory)
+      Lib.logger.debug("  changed window: " .. tostring(vim.v.event.changed_window))
+      Lib.logger.debug("  scope: " .. vim.v.event.scope)
 
-        -- Don't want to save session if dir change was triggered
-        -- by a window change. This will corrupt the session data,
-        -- mixing the two different directory sessions
-        if vim.v.event.changed_window then
-          return
-        end
+      -- Don't want to save session if dir change was triggered
+      -- by a window change. This will corrupt the session data,
+      -- mixing the two different directory sessions
+      if vim.v.event.changed_window then
+        return
+      end
 
-        AutoSession.AutoSaveSession()
+      AutoSession.AutoSaveSession()
 
-        -- Clear all buffers and jumps after session save so session doesn't blead over to next session.
-        vim.cmd "%bd!"
-        vim.cmd "clearjumps"
+      -- Clear all buffers and jumps after session save so session doesn't blead over to next session.
+      vim.cmd "%bd!"
+      vim.cmd "clearjumps"
 
-        if type(conf.pre_cwd_changed_hook) == "function" then
-          conf.pre_cwd_changed_hook()
-        end
-      end,
-      pattern = pattern,
-    })
+      if type(conf.pre_cwd_changed_hook) == "function" then
+        conf.pre_cwd_changed_hook()
+      end
+    end,
+    pattern = "global",
+  })
 
-    if conf.restore_upcoming_session then
-        vim.api.nvim_create_autocmd("DirChanged", {
-          callback = function()
-            Lib.logger.debug "DirChanged"
-            Lib.logger.debug("  cwd: " .. vim.fn.getcwd() )
-            Lib.logger.debug("  changed window: " .. tostring(vim.v.event.changed_window))
-            Lib.logger.debug("  scope: " .. vim.v.event.scope)
+  if conf.restore_upcoming_session then
+      vim.api.nvim_create_autocmd("DirChanged", {
+        callback = function()
+          Lib.logger.debug "DirChanged"
+          Lib.logger.debug("  cwd: " .. vim.fn.getcwd() )
+          Lib.logger.debug("  changed window: " .. tostring(vim.v.event.changed_window))
+          Lib.logger.debug("  scope: " .. vim.v.event.scope)
 
-            -- see above
-            if vim.v.event.changed_window then
-              return
-            end
+          -- see above
+          if vim.v.event.changed_window then
+            return
+          end
 
-            -- all buffers should've been deleted in `DirChangedPre`, something probably went wrong
-            if has_open_buffers() then
-              Lib.logger.debug("Cancelling session restore")
-              return
-            end
+          -- all buffers should've been deleted in `DirChangedPre`, something probably went wrong
+          if Lib.has_open_buffers() then
+            Lib.logger.debug("Cancelling session restore")
+            return
+          end
 
-            local success = AutoSession.AutoRestoreSession()
+          local success = AutoSession.AutoRestoreSession()
 
-            if not success then
-              Lib.logger.info("Could not load session. A session file is likely missing for this cwd." .. vim.fn.getcwd())
-              return
-            end
+          if not success then
+            Lib.logger.info("Could not load session. A session file is likely missing for this cwd." .. vim.fn.getcwd())
+            return
+          end
 
-            if type(conf.post_cwd_changed_hook) == "function" then
-              conf.post_cwd_changed_hook()
-            end
-          end,
-          pattern = pattern,
-        })
-    end
+          if type(conf.post_cwd_changed_hook) == "function" then
+            conf.post_cwd_changed_hook()
+          end
+        end,
+        pattern = "global",
+      })
   end
 end
 

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -175,4 +175,29 @@ function Lib.logger.error(...)
   vim.notify(vim.fn.join({ "error: ", tostring(...) }, " "), vim.log.levels.ERROR)
 end
 
+-- return type of file tree explorer or false if not a file tree explorers
+function Lib.tree_buf_type(bufnr)
+  if bufnr == nil then
+    bufnr = 0
+  end
+  if vim.fn.bufexists(bufnr) then
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
+    local filename = vim.fn.fnamemodify(bufname, ":t")
+    if filename:match "^NvimTree_[0-9]+$" then
+      if vim.bo[bufnr].filetype == "NvimTree" then
+        return "nvimtree"
+      elseif vim.fn.filereadable(bufname) == 0 then
+        return "nvimtree"
+      end
+    elseif filename:match "^NERD_tree_[0-9]+$" then
+      if vim.bo[bufnr].filetype == "nerdtree" then
+        return "nerdtree"
+      elseif vim.fn.filereadable(bufname) == 0 then
+        return "nerdtree"
+      end
+    end
+  end
+  return false
+end
+
 return Lib

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -158,6 +158,26 @@ function Lib.expand(file_or_dir)
   return ret
 end
 
+function Lib.has_open_buffers()
+  local result = false
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.fn.bufloaded(bufnr) then
+      local bufname = vim.api.nvim_buf_get_name(bufnr)
+      if bufname ~= "" then
+        if vim.fn.bufwinnr(bufnr) ~= -1 then
+          if result then
+            result = true
+            Lib.logger.debug("There are buffer(s) present: ")
+          end
+          Lib.logger.debug("  " .. bufname)
+        end
+      end
+    end
+  end
+  return result
+end
+
+
 function Lib.logger.debug(...)
   if Lib.conf.log_level == "debug" then
     vim.notify(vim.fn.join({ "debug: ", tostring(...) }, " "), vim.log.levels.DEBUG)

--- a/lua/auto-session-library.lua
+++ b/lua/auto-session-library.lua
@@ -175,29 +175,4 @@ function Lib.logger.error(...)
   vim.notify(vim.fn.join({ "error: ", tostring(...) }, " "), vim.log.levels.ERROR)
 end
 
--- return type of file tree explorer or false if not a file tree explorers
-function Lib.tree_buf_type(bufnr)
-  if bufnr == nil then
-    bufnr = 0
-  end
-  if vim.fn.bufexists(bufnr) then
-    local bufname = vim.api.nvim_buf_get_name(bufnr)
-    local filename = vim.fn.fnamemodify(bufname, ":t")
-    if filename:match "^NvimTree_[0-9]+$" then
-      if vim.bo[bufnr].filetype == "NvimTree" then
-        return "nvimtree"
-      elseif vim.fn.filereadable(bufname) == 0 then
-        return "nvimtree"
-      end
-    elseif filename:match "^NERD_tree_[0-9]+$" then
-      if vim.bo[bufnr].filetype == "nerdtree" then
-        return "nerdtree"
-      elseif vim.fn.filereadable(bufname) == 0 then
-        return "nerdtree"
-      end
-    end
-  end
-  return false
-end
-
 return Lib

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -500,7 +500,8 @@ local function post_restore_refresh()
       -- we only open the tree if it was open before
       if (tree_type == "nvimtree") then
         pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-        require('nvim-tree').open()
+        -- want no focus to avoid "'modifiable' is off" errors
+        require('nvim-tree').toggle(false, true)
       elseif (tree_type == "nerdtree") then
         pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         vim.cmd 'NERDTreeOpen'

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -47,7 +47,6 @@ local AutoSession = {
 local defaultConf = {
   log_level = vim.g.auto_session_log_level or AutoSession.conf.logLevel or AutoSession.conf.log_level or "info", -- Sets the log level of the plugin (debug, info, error). camelCase logLevel for compatibility.
   auto_session_enable_last_session = vim.g.auto_session_enable_last_session or false, -- Enables/disables the "last session" feature
-  auto_session_enable_file_tree_integration = vim.g.auto_session_enable_file_tree_integration or false, -- Enables/disables the "last session" feature
   auto_session_root_dir = vim.fn.stdpath "data" .. "/sessions/", -- Root dir where sessions will be stored
   auto_session_enabled = true, -- Enables/disables auto creating, saving and restoring
   auto_session_create_enabled = nil, -- Enables/disables auto creating new sessions
@@ -486,28 +485,11 @@ end
 local function post_restore_refresh()
   -- refresh sytax highlighting
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if not vim.api.nvim_buf_is_loaded(bufnr) then
-      goto continue
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      vim.api.nvim_buf_call(bufnr, function()
+        vim.cmd 'filetype detect'
+      end)
     end
-
-    vim.api.nvim_buf_call(bufnr, function()
-      vim.cmd 'filetype detect'
-    end)
-
-    if AutoSession.conf.auto_session_enable_file_tree_integration then
-      -- refresh file trees
-      local tree_type = Lib.tree_buf_type(bufnr)
-      -- we only open the tree if it was open before
-      if (tree_type == "nvimtree") then
-        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-        -- want no focus to avoid "'modifiable' is off" errors
-        require('nvim-tree').toggle(false, true)
-      elseif (tree_type == "nerdtree") then
-        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-        vim.cmd 'NERDTreeOpen'
-      end
-    end
-    ::continue::
   end
 end
 


### PR DESCRIPTION
This enables file tree integration with `nvim-tree` and `NERDTree`.

It is [fairly difficult](https://github.com/rmagatti/auto-session/issues/178) to get sessions and file tree browsers to play nicely together, but when you do, the result is spectacular.

As such, I thought I'd make it easier to integrate the two with a simple configuration option:

```lua
require 'nvim-tree'.setup {
  auto_session_enable_file_tree_integration = true,
}
```

This *hopefully* fixes:

* https://github.com/rmagatti/auto-session/issues/178
* https://github.com/rmagatti/auto-session/issues/50

And would be a solution for people struggling with sessions/file trees elsewhere as well:

* https://github.com/preservim/nerdtree/issues/745
* https://github.com/preservim/nerdtree/issues/337
* https://github.com/nvim-tree/nvim-tree.lua/issues/309
* https://github.com/nvim-tree/nvim-tree.lua/issues/591
* https://github.com/nvim-tree/nvim-tree.lua/issues/488
* https://github.com/nvim-tree/nvim-tree.lua/issues/296