### PR TITLE
revert filetype detect, save localoptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Auto Session takes advantage of Neovim's existing session management capabilitie
 :warning: Please note that if there are errors in your config, restoring the session might fail, if that happens, auto session will then disable auto saving for the current session.
 Manually saving a session can still be done by calling `:SaveSession`.
 
-AutoSession now tracks `cwd` changes!  
-By default, handling is as follows:  
-  DirChangedPre (before the cwd actually changes):  
-    - Save the current session  
-    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the  
-      next session.  
-    - Clear jumps. Also done so there is no bleading between sessions.  
-    - Run the `pre_cwd_changed_hook`  
-  DirChanged (after the cwd has changed):  
-    - Restore session using new cwd  
-    - Run the `post_cwd_changed_hook`  
-    
+AutoSession now tracks `cwd` changes!
+By default, handling is as follows:
+  DirChangedPre (before the cwd actually changes):
+    - Save the current session
+    - Clear all buffers `%bd!`. This guarantees buffers don't bleed to the
+      next session.
+    - Clear jumps. Also done so there is no bleading between sessions.
+    - Run the `pre_cwd_changed_hook`
+  DirChanged (after the cwd has changed):
+    - Restore session using new cwd
+    - Run the `post_cwd_changed_hook`
+
 Now when the user changes the cwd with `:cd some/new/dir` auto-session handles it gracefully, saving the current session so there aren't losses and loading the session for the upcoming cwd if it exists.
 
 Hooks are available for custom actions _before_ and _after_ the `cwd` is changed. These hooks can be configured through the `cwd_change_handling` key as follows:
@@ -150,7 +150,7 @@ For a better experience with the plugin overall using this config for `sessionop
 **Lua**
 
 ```lua
-vim.o.sessionoptions="blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal"
+vim.o.sessionoptions="blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
 ```
 
 **VimL**

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -480,19 +480,6 @@ function AutoSession.RestoreSessionFromFile(session_file)
   AutoSession.RestoreSession(string.format(AutoSession.get_root_dir() .. "%s.vim", session_file:gsub("/", "%%")))
 end
 
---
--- Refresh syntax highlighting and file trees
-local function post_restore_refresh()
-  -- refresh sytax highlighting
-  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if vim.api.nvim_buf_is_loaded(bufnr) then
-      vim.api.nvim_buf_call(bufnr, function()
-        vim.cmd 'filetype detect'
-      end)
-    end
-  end
-end
-
 -- TODO: make this more readable!
 ---Restores the session by sourcing the session file if it exists/is readable.
 ---This function is intended to be called by the user but it is also called by `AutoRestoreSession`
@@ -526,8 +513,6 @@ function AutoSession.RestoreSession(sessions_dir_or_file)
 
     local post_cmds = AutoSession.get_cmds "post_restore"
     run_hook_cmds(post_cmds, "post-restore")
-
-    vim.defer_fn(post_restore_refresh, 0)
   end
 
   -- I still don't like reading this chunk, please cleanup


### PR DESCRIPTION
See https://github.com/rmagatti/auto-session/pull/179#issuecomment-1307567366

Save local options which will restore syntax highlighting, as well as `wrap` and `number` options