### PR TITLE
Bump neovim version to v0.7.0

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: emmylua to vimdoc
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Generating help
         run: |

--- a/README.md
+++ b/README.md
@@ -286,7 +286,5 @@ Neovim > 0.5
 Tested with:
 
 ```
-NVIM v0.5.0-dev+a1ec36f
-Build type: Release
-LuaJIT 2.1.0-beta3
+NVIM v0.7.0
 ```

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -7,10 +7,10 @@ defaultConf                                                        *defaultConf*
         {auto_session_root_dir}             (string)       root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
         {auto_session_enabled}              (boolean)      enable auto session
         {auto_session_create_enabled}       (boolean|nil)  Enables/disables auto creating new sessions
-        {auto_save_enabled}                 (boolean|nil)  Enables/disables auto saving session
-        {auto_restore_enabled}              (boolean|nil)  Enables/disables auto restoring session
-        {auto_session_allowed_dirs}         (table|nil)    Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
-                                                           @fied auto_session_suppress_dirs table|nil Suppress auto session for directories
+        {auto_save_enabled?}                (boolean)      Enables/disables auto saving session
+        {auto_restore_enabled?}             (boolean)      Enables/disables auto restoring session
+        {auto_session_suppress_dirs?}       (table)        Suppress auto session for directories
+        {auto_session_allowed_dirs?}        (table)        Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
         {auto_session_use_git_branch}       (boolean|nil)  Include git branch name in session name to differentiate between sessions for different git branches
 
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -18,6 +18,7 @@ luaOnlyConf                                                        *luaOnlyConf*
     Lua Only Configs for Auto Session
 
     Fields: ~
+        {cwd_change_handling}             (CwdChangeHandling)
         {bypass_session_save_file_types}  (string)
 
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,10 +1,32 @@
 defaultConf                                                        *defaultConf*
+    table default config for auto session
+
+    Fields: ~
+        {log_level}                         (string)       debug, info, error
+        {auto_session_enable_last_session}  (boolean)
+        {auto_session_root_dir}             (string)       root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
+        {auto_session_enabled}              (boolean)      enable auto session
+        {auto_session_create_enabled}       (boolean|nil)  Enables/disables auto creating new sessions
+        {auto_save_enabled}                 (boolean|nil)  Enables/disables auto saving session
+        {auto_restore_enabled}              (boolean|nil)  Enables/disables auto restoring session
+        {auto_session_allowed_dirs}         (table|nil)    Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
+                                                           @fied auto_session_suppress_dirs table|nil Suppress auto session for directories
+        {auto_session_use_git_branch}       (boolean|nil)  Include git branch name in session name to differentiate between sessions for different git branches
 
 
 luaOnlyConf                                                        *luaOnlyConf*
+    Lua Only Configs for Auto Session
+
+    Fields: ~
+        {bypass_session_save_file_types}  (string)
 
 
 CwdChangeHandling                                            *CwdChangeHandling*
+    CWD Change Handling Config
+
+    Fields: ~
+        {restore_upcoming_session}  (boolean)  {true} restore session for upcoming cwd on cwd change
+        {pre_cwd_changed_hook}      (boolean)
 
 
 AutoSession.setup({config})                                  *AutoSession.setup*

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,33 +1,10 @@
 defaultConf                                                        *defaultConf*
-    table default config for auto session
-
-    Fields: ~
-        {log_level}                         (string)       debug, info, error
-        {auto_session_enable_last_session}  (boolean)
-        {auto_session_root_dir}             (string)       root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
-        {auto_session_enabled}              (boolean)      enable auto session
-        {auto_session_create_enabled}       (boolean|nil)  Enables/disables auto creating new sessions
-        {auto_save_enabled}                 (boolean|nil)  Enables/disables auto saving session
-        {auto_restore_enabled}              (boolean|nil)  Enables/disables auto restoring session
-        {auto_session_allowed_dirs}         (table|nil)    Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
-        {auto_session_use_git_branch}       (boolean|nil)  Include git branch name in session name to differentiate between sessions for different git branches
 
 
 luaOnlyConf                                                        *luaOnlyConf*
-    Lua Only Configs for Auto Session
-
-    Fields: ~
-        {bypass_session_save_file_types}  (string?)            Bypass auto save when only buffer open is one of these file types
-        {cwd_change_handling}             (CwdChangeHandling)
 
 
 CwdChangeHandling                                            *CwdChangeHandling*
-    CWD Change Handling Config
-
-    Fields: ~
-        {restore_upcoming_session}  (boolean)   {true} restore session for upcoming cwd on cwd change
-        {pre_cwd_changed_hook}      (boolean?)  {true} This is called after auto_session code runs for the `DirChangedPre` autocmd
-        {post_cwd_changed_hook}     (boolean?)  {true} This is called after auto_session code runs for the `DirChanged` autocmd
 
 
 AutoSession.setup({config})                                  *AutoSession.setup*
@@ -44,13 +21,7 @@ AutoSession.get_latest_session()                *AutoSession.get_latest_session*
         {string|nil}
 
 
-                                                   *AutoSession.AutoSaveSession*
-AutoSession.AutoSaveSession({sessions_dir})
-    AutoSaveSession
-    Function called by auto_session to trigger auto_saving sessions, for example on VimExit events.
-
-    Parameters: ~
-        {sessions_dir}  (string?)  the session directory to auto_save a session for. If empty this function will end up using the cwd to infer what session to save for.
+AutoSession.AutoSaveSession()                      *AutoSession.AutoSaveSession*
 
 
 AutoSession.get_root_dir()                            *AutoSession.get_root_dir*
@@ -74,7 +45,6 @@ AutoSession.get_cmds({typ})                               *AutoSession.get_cmds*
 
 PickerItem                                                          *PickerItem*
 
-
     Fields: ~
         {display_name}  (string)
         {path}          (string)
@@ -92,21 +62,16 @@ AutoSession.format_file_name({path})              *AutoSession.format_file_name*
 
 AutoSession.get_session_files()                  *AutoSession.get_session_files*
 
-
     Returns: ~
         {PickerItem[]}
 
 
-                                                       *AutoSession.SaveSession*
-AutoSession.SaveSession({sessions_dir}, {auto})
-
+AutoSession.SaveSession({auto})                        *AutoSession.SaveSession*
 
     Parameters: ~
-        {sessions_dir}  (string?)
-        {auto}          (boolean)
+        {auto}  (boolean)
 
 
-                                                *AutoSession.AutoRestoreSession*
 AutoSession.AutoRestoreSession({sessions_dir})
     Function called by AutoSession when automatically restoring a session.
     This function avoids calling RestoreSession automatically when argv is not nil.
@@ -118,7 +83,6 @@ AutoSession.AutoRestoreSession({sessions_dir})
         {boolean}  returns whether restoring the session was successful or not.
 
 
-                                            *AutoSession.RestoreSessionFromFile*
 AutoSession.RestoreSessionFromFile({session_file})
     RestoreSessionFromFile takes a session_file and calls RestoreSession after parsing the provided parameter.
 
@@ -126,7 +90,6 @@ AutoSession.RestoreSessionFromFile({session_file})
         {session_file}  (string)
 
 
-                                                    *AutoSession.RestoreSession*
 AutoSession.RestoreSession({sessions_dir_or_file})
     Restores the session by sourcing the session file if it exists/is readable.
     This function is intended to be called by the user but it is also called by `AutoRestoreSession`
@@ -150,21 +113,16 @@ AutoSession.CompleteSessions()                    *AutoSession.CompleteSessions*
         {string}
 
 
-AutoSession.DeleteSessionByName({...})         *AutoSession.DeleteSessionByName*
+AutoSession.DeleteSessionByName()              *AutoSession.DeleteSessionByName*
     DeleteSessionByName deletes sessions given a provided list of paths
-
-    Parameters: ~
-        {...}  (string[])
+    @param ... string[]
 
 
-AutoSession.DeleteSession({...})                     *AutoSession.DeleteSession*
+AutoSession.DeleteSession()                          *AutoSession.DeleteSession*
     DeleteSession delets a single session given a provided path
-
-    Parameters: ~
-        {...}  (string[])
+    @param ... string[]
 
 
-                                                              *M.setup_autocmds*
 M.setup_autocmds({config}, {AutoSession})
     Setup autocmds for DirChangedPre and DirChanged
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,10 +1,33 @@
 defaultConf                                                        *defaultConf*
+    table default config for auto session
+
+    Fields: ~
+        {log_level}                         (string)       debug, info, error
+        {auto_session_enable_last_session}  (boolean)
+        {auto_session_root_dir}             (string)       root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
+        {auto_session_enabled}              (boolean)      enable auto session
+        {auto_session_create_enabled}       (boolean|nil)  Enables/disables auto creating new sessions
+        {auto_save_enabled}                 (boolean|nil)  Enables/disables auto saving session
+        {auto_restore_enabled}              (boolean|nil)  Enables/disables auto restoring session
+        {auto_session_allowed_dirs}         (table|nil)    Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
+        {auto_session_use_git_branch}       (boolean|nil)  Include git branch name in session name to differentiate between sessions for different git branches
 
 
 luaOnlyConf                                                        *luaOnlyConf*
+    Lua Only Configs for Auto Session
+
+    Fields: ~
+        {bypass_session_save_file_types}  (string?)            Bypass auto save when only buffer open is one of these file types
+        {cwd_change_handling}             (CwdChangeHandling)
 
 
 CwdChangeHandling                                            *CwdChangeHandling*
+    CWD Change Handling Config
+
+    Fields: ~
+        {restore_upcoming_session}  (boolean)   {true} restore session for upcoming cwd on cwd change
+        {pre_cwd_changed_hook}      (boolean?)  {true} This is called after auto_session code runs for the `DirChangedPre` autocmd
+        {post_cwd_changed_hook}     (boolean?)  {true} This is called after auto_session code runs for the `DirChanged` autocmd
 
 
 AutoSession.setup({config})                                  *AutoSession.setup*
@@ -21,7 +44,13 @@ AutoSession.get_latest_session()                *AutoSession.get_latest_session*
         {string|nil}
 
 
-AutoSession.AutoSaveSession()                      *AutoSession.AutoSaveSession*
+                                                   *AutoSession.AutoSaveSession*
+AutoSession.AutoSaveSession({sessions_dir})
+    AutoSaveSession
+    Function called by auto_session to trigger auto_saving sessions, for example on VimExit events.
+
+    Parameters: ~
+        {sessions_dir}  (string?)  the session directory to auto_save a session for. If empty this function will end up using the cwd to infer what session to save for.
 
 
 AutoSession.get_root_dir()                            *AutoSession.get_root_dir*
@@ -45,6 +74,7 @@ AutoSession.get_cmds({typ})                               *AutoSession.get_cmds*
 
 PickerItem                                                          *PickerItem*
 
+
     Fields: ~
         {display_name}  (string)
         {path}          (string)
@@ -62,16 +92,21 @@ AutoSession.format_file_name({path})              *AutoSession.format_file_name*
 
 AutoSession.get_session_files()                  *AutoSession.get_session_files*
 
+
     Returns: ~
         {PickerItem[]}
 
 
-AutoSession.SaveSession({auto})                        *AutoSession.SaveSession*
+                                                       *AutoSession.SaveSession*
+AutoSession.SaveSession({sessions_dir}, {auto})
+
 
     Parameters: ~
-        {auto}  (boolean)
+        {sessions_dir}  (string?)
+        {auto}          (boolean)
 
 
+                                                *AutoSession.AutoRestoreSession*
 AutoSession.AutoRestoreSession({sessions_dir})
     Function called by AutoSession when automatically restoring a session.
     This function avoids calling RestoreSession automatically when argv is not nil.
@@ -83,6 +118,7 @@ AutoSession.AutoRestoreSession({sessions_dir})
         {boolean}  returns whether restoring the session was successful or not.
 
 
+                                            *AutoSession.RestoreSessionFromFile*
 AutoSession.RestoreSessionFromFile({session_file})
     RestoreSessionFromFile takes a session_file and calls RestoreSession after parsing the provided parameter.
 
@@ -90,6 +126,7 @@ AutoSession.RestoreSessionFromFile({session_file})
         {session_file}  (string)
 
 
+                                                    *AutoSession.RestoreSession*
 AutoSession.RestoreSession({sessions_dir_or_file})
     Restores the session by sourcing the session file if it exists/is readable.
     This function is intended to be called by the user but it is also called by `AutoRestoreSession`
@@ -113,16 +150,21 @@ AutoSession.CompleteSessions()                    *AutoSession.CompleteSessions*
         {string}
 
 
-AutoSession.DeleteSessionByName()              *AutoSession.DeleteSessionByName*
+AutoSession.DeleteSessionByName({...})         *AutoSession.DeleteSessionByName*
     DeleteSessionByName deletes sessions given a provided list of paths
-    @param ... string[]
+
+    Parameters: ~
+        {...}  (string[])
 
 
-AutoSession.DeleteSession()                          *AutoSession.DeleteSession*
+AutoSession.DeleteSession({...})                     *AutoSession.DeleteSession*
     DeleteSession delets a single session given a provided path
-    @param ... string[]
+
+    Parameters: ~
+        {...}  (string[])
 
 
+                                                              *M.setup_autocmds*
 M.setup_autocmds({config}, {AutoSession})
     Setup autocmds for DirChangedPre and DirChanged
 

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -68,8 +68,8 @@ local luaOnlyConf = {
   ---CWD Change Handling Config
   ---@class CwdChangeHandling
   ---@field restore_upcoming_session boolean {true} restore session for upcoming cwd on cwd change
-  ---@field pre_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the `DirChangedPre` autocmd
-  ---@field post_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the `DirChanged` autocmd
+  ---@field pre_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the DirChangedPre autocmd
+  ---@field post_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the DirChanged autocmd
 
   ---@type CwdChangeHandling this config can also be set to `false` to disable cwd change handling altogether.
   --- Can also be set to a table with any of the following keys:

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -30,7 +30,8 @@ local AutoSession = {
   conf = {},
 }
 
----@class defaultConf table default config for auto session
+---table default config for auto session
+---@class defaultConf
 ---@field log_level string debug, info, error
 ---@field auto_session_enable_last_session boolean
 ---@field auto_session_root_dir string root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
@@ -57,13 +58,15 @@ local defaultConf = {
   auto_session_use_git_branch = vim.g.auto_session_use_git_branch or false,
 }
 
----@class luaOnlyConf Lua Only Configs for Auto Session
+---Lua Only Configs for Auto Session
+---@class luaOnlyConf
 ---@field bypass_session_save_file_types string? Bypass auto save when only buffer open is one of these file types
 ---@field cwd_change_handling CwdChangeHandling
 local luaOnlyConf = {
   bypass_session_save_file_types = nil, -- Bypass auto save when only buffer open is one of these file types
 
-  ---@class CwdChangeHandling CWD Change Handling Config
+  ---CWD Change Handling Config
+  ---@class CwdChangeHandling
   ---@field restore_upcoming_session boolean {true} restore session for upcoming cwd on cwd change
   ---@field pre_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the `DirChangedPre` autocmd
   ---@field post_cwd_changed_hook boolean? {true} This is called after auto_session code runs for the `DirChanged` autocmd

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -60,8 +60,8 @@ local defaultConf = {
 
 ---Lua Only Configs for Auto Session
 ---@class luaOnlyConf
----@field bypass_session_save_file_types string? Bypass auto save when only buffer open is one of these file types
 ---@field cwd_change_handling CwdChangeHandling
+---@field bypass_session_save_file_types string? Bypass auto save when only buffer open is one of these file types
 local luaOnlyConf = {
   bypass_session_save_file_types = nil, -- Bypass auto save when only buffer open is one of these file types
 

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -37,10 +37,10 @@ local AutoSession = {
 ---@field auto_session_root_dir string root directory for session files, by default is `vim.fn.stdpath('data')/sessions/`
 ---@field auto_session_enabled boolean enable auto session
 ---@field auto_session_create_enabled boolean|nil Enables/disables auto creating new sessions
----@field auto_save_enabled boolean|nil Enables/disables auto saving session
----@field auto_restore_enabled boolean|nil Enables/disables auto restoring session
----@fied auto_session_suppress_dirs table|nil Suppress auto session for directories
----@field auto_session_allowed_dirs table|nil Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
+---@field auto_save_enabled? boolean Enables/disables auto saving session
+---@field auto_restore_enabled? boolean Enables/disables auto restoring session
+---@field auto_session_suppress_dirs? table Suppress auto session for directories
+---@field auto_session_allowed_dirs? table Allow auto session for directories, if empty then all directories are allowed except for suppressed ones
 ---@field auto_session_use_git_branch boolean|nil Include git branch name in session name to differentiate between sessions for different git branches
 
 ---Default config for auto session

--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -61,7 +61,7 @@ local defaultConf = {
 ---Lua Only Configs for Auto Session
 ---@class luaOnlyConf
 ---@field cwd_change_handling CwdChangeHandling
----@field bypass_session_save_file_types string? Bypass auto save when only buffer open is one of these file types
+---@field bypass_session_save_file_types? string Bypass auto save when only buffer open is one of these file types
 local luaOnlyConf = {
   bypass_session_save_file_types = nil, -- Bypass auto save when only buffer open is one of these file types
 
@@ -306,7 +306,7 @@ end
 
 ---AutoSaveSession
 ---Function called by auto_session to trigger auto_saving sessions, for example on VimExit events.
----@param sessions_dir string? the session directory to auto_save a session for. If empty this function will end up using the cwd to infer what session to save for.
+---@param sessions_dir? string the session directory to auto_save a session for. If empty this function will end up using the cwd to infer what session to save for.
 function AutoSession.AutoSaveSession(sessions_dir)
   if auto_save_conditions_met() then
     if not is_auto_create_enabled() then
@@ -428,7 +428,7 @@ end
 vim.api.nvim_create_user_command("Autosession", handle_autosession_command, { nargs = 1 })
 
 --Saves the session, overriding if previously existing.
----@param sessions_dir string?
+---@param sessions_dir? string
 ---@param auto boolean
 function AutoSession.SaveSession(sessions_dir, auto)
   Lib.logger.debug "==== SaveSession"


### PR DESCRIPTION
Closes #181

Also fixes the help docs to work with the newest version of lemmy-help.

Reference:
https://github.com/numToStr/lemmy-help/pull/47
https://github.com/numToStr/lemmy-help/pull/37

There seems to be an issue still with parsing a vararg param:
https://github.com/numToStr/lemmy-help/issues/61