### PR TITLE
fix: don't consider embedded mode headless mode

### DIFF
--- a/lua/auto-session.lua
+++ b/lua/auto-session.lua
@@ -162,7 +162,7 @@ local in_pager_mode = function()
 end
 
 local in_headless_mode = function()
-  return not next(vim.api.nvim_list_uis())
+  return not vim.tbl_contains(vim.v.argv, '--embed') and not next(vim.api.nvim_list_uis())
 end
 
 local auto_save = function()


### PR DESCRIPTION
Problem:
When a UI that uses --embed closes channel, there are no UIs attached when the VimLeave autocommand is triggred, and auto-session detects this as headless mode.

Solution:
Don't detect Nvim invoked with --embed as headless mode.

Fix https://github.com/neovim/neovim/issues/22972