### PR TITLE
fix: windows invert escappe dir

### DIFF
--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -95,7 +95,7 @@ function Lib.init_file(file_path)
   end
 end
 
-local function win32_escaped_dir(dir)
+local function win32_unescaped_dir(dir)
   dir = dir:gsub("++", ":")
   if not vim.o.shellslash then
     dir = dir:gsub("-", "\\")
@@ -104,7 +104,7 @@ local function win32_escaped_dir(dir)
   return dir
 end
 
-local function win32_unescaped_dir(dir)
+local function win32_escaped_dir(dir)
   dir = dir:gsub(":", "++")
   if not vim.o.shellslash then
     dir = dir:gsub("\\", "-")


### PR DESCRIPTION
A bug about failing to save session was introduced in #227 on Windows. This PR fixes it.

I've isolated the changes to WIN32 now, so it'll not have regression on other OS

Fix #220 