### PR TITLE
Fix auto_session_use_git_branch functionality (#236)

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -321,7 +321,7 @@ local function get_session_file_name(upcoming_session_dir)
 
       -- Was getting %U issue on path without this, directory was unescaped
       -- session_name = string.gsub(session_name, "%.", "%%%.")
-      -- session_name = string.format("%s%s", session_name, branch_name)
+      session_name = string.format("%s%s", session_name, branch_name)
 
       Lib.logger.debug("session name post-format", { session_name = session_name })
     end


### PR DESCRIPTION
This fixes an issue where the auto_session_use_git_branch had no effect. I tested this on MacOS with nvim 0.9. The code that gets the branch name (`get_branch_name`) was executing, but the code that appended the branch name to the session was commented out in c3f35994 for some reason. The `get_branch_name` function is where the auto_session_use_git_branch option is checked and it will return an empty string if it is not set.