### PR TITLE
Improve log messages

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -657,9 +657,9 @@ function AutoSession.RestoreSession(sessions_dir_or_file)
 
     if not success then
       Lib.logger.error([[
-        Error restoring session! The session might be corrupted.
-        Disabling auto save. Please check for errors in your config. Error:
-      ]] .. result)
+Error restoring session! The session might be corrupted.
+Disabling auto save. Please check for errors in your config. Error:
+]] .. result)
       AutoSession.conf.auto_save_enabled = false
       return
     end

--- a/lua/auto-session/logger.lua
+++ b/lua/auto-session/logger.lua
@@ -3,17 +3,14 @@ local Logger = {}
 ---Function that handles vararg printing, so logs are consistent.
 local function to_print(...)
   local args = { ... }
-  if #args == 1 and type(...) == "table" then
-    return vim.inspect(...)
-  else
-    local to_return = ""
 
-    for _, value in ipairs(args) do
-      to_return = vim.fn.join({ to_return, vim.inspect(value) }, " ")
+  for i, value in ipairs(args) do
+    if type(value) ~= "string" then
+      args[i] = vim.inspect(value)
     end
-
-    return to_return
   end
+
+  return vim.fn.join(args, " ")
 end
 
 function Logger:new(obj_and_config)
@@ -38,7 +35,7 @@ end
 
 function Logger:debug(...)
   if self.log_level == "debug" or self.log_level == vim.log.levels.DEBUG then
-    vim.notify(vim.fn.join({ "auto-session DEBUG:", to_print(...) }, " "), vim.log.levels.DEBUG)
+    vim.notify("auto-session DEBUG: " .. to_print(...), vim.log.levels.DEBUG)
   end
 end
 
@@ -46,7 +43,7 @@ function Logger:info(...)
   local valid_values = { "info", "debug", vim.log.levels.DEBUG, vim.log.levels.INFO }
 
   if vim.tbl_contains(valid_values, self.log_level) then
-    vim.notify(vim.fn.join({ "auto-session INFO:", to_print(...) }, " "), vim.log.levels.INFO)
+    vim.notify("auto-session INFO: " .. to_print(...), vim.log.levels.INFO)
   end
 end
 
@@ -54,12 +51,12 @@ function Logger:warn(...)
   local valid_values = { "info", "debug", "warn", vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN }
 
   if vim.tbl_contains(valid_values, self.log_level) then
-    vim.notify(vim.fn.join({ "auto-session WARN:", to_print(...) }, " "), vim.log.levels.WARN)
+    vim.notify("auto-session WARN: " .. to_print(...), vim.log.levels.WARN)
   end
 end
 
 function Logger:error(...)
-  vim.notify(vim.fn.join({ "auto-session ERROR:", to_print(...) }, " "), vim.log.levels.ERROR)
+  vim.notify("auto-session ERROR: " .. to_print(...), vim.log.levels.ERROR)
 end
 
 return Logger


### PR DESCRIPTION
This is a very simple improvement to log messages displayed by the plugin, specifically the error when restoring a session fails.

I often find myself accidentally opening a session which is already open somewhere else, which usually causes Neovim to try and open files which are in use. I then realise that I've made a mistake and hit abort on the "are you sure you want to open the file" popup, which then causes the session restore to fail. Auto-session then displays an error message and very helpfully disables auto-save.

What this PR does is change the `to_print` function to avoid passing strings directly to `vim.inspect`, because that causes linebreaks to be displayed as literal `\n`'s in the restore session error message. I've also removed the indentation from the message, to make it look a bit nicer.