### PR TITLE
ignore tralling slash clean when folder = /

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -259,7 +259,9 @@ local function suppress_session()
 
   local cwd = vim.fn.getcwd()
   for _, s in pairs(dirs) do
-    s = string.gsub(vim.fn.simplify(Lib.expand(s)), "/+$", "")
+    if s ~= "/" then
+      s = string.gsub(vim.fn.simplify(Lib.expand(s)), "/+$", "")
+    end
     for path in string.gmatch(s, "[^\r\n]+") do
       if cwd == path then
         return true


### PR DESCRIPTION
Discovered when  you start `neovide` your root folder is `/` and if this folder is suppressed it still appears in a list.

my config 
```lua
return {
  "rmagatti/auto-session",
  config = function()
    require("auto-session").setup({
      log_level = "debug",
      auto_session_suppress_dirs = { "~/", "~/Desktop", "~/Downloads", "/" },
      session_lens = {
        -- If load_on_setup is set to false, one needs to eventually call `require("auto-session").setup_session_lens()` if they want to use session-lens.
        -- shorten_path = true,
        load_on_setup = true,
        theme_conf = { border = true },
        previewer = false,
      },
    })
    vim.keymap.set("n", "<S-D-p>", require("auto-session.session-lens").search_session, { noremap = true })
  end,
}

```