### PR TITLE
add filter for buffer deleation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ require("auto-session").setup {
   -- The following are already the default values, no need to provide them if these are already the settings you want.
   session_lens = {
     -- If load_on_setup is set to false, one needs to eventually call `require("auto-session").setup_session_lens()` if they want to use session-lens.
+    buftypes_to_ignore = {}, -- list of buffer types what should not be deleted from current session
     load_on_setup = true,
     theme_conf = { border = true },
     previewer = false,

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -89,6 +89,7 @@ local luaOnlyConf = {
 
   ---@type session_lens_config
   session_lens = {
+    buftypes_to_ignore = {}, -- list of bufftypes to ignore when switching between sessions
     load_on_setup = true,
     session_control = {
       control_dir = vim.fn.stdpath "data" .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens

--- a/lua/auto-session/session-lens/actions.lua
+++ b/lua/auto-session/session-lens/actions.lua
@@ -51,7 +51,14 @@ local function source_session(selection, prompt_bufnr)
     else
       Lib.logger.debug "Triggering session-lens behaviour since cwd_change_handling feature is disabled"
       M.functions.AutoSaveSession()
-      vim.cmd "%bd!"
+
+      local buffers = vim.api.nvim_list_bufs()
+      for _, bufn in pairs(buffers) do
+        if not vim.tbl_contains(M.conf.buftypes_to_ignore, vim.api.nvim_buf_get_option(bufn, "buftype")) then
+          vim.cmd("silent bwipeout!" .. bufn)
+        end
+      end
+
       vim.cmd "clearjumps"
       M.functions.RestoreSession(type(selection) == "table" and selection.path or selection)
     end

--- a/lua/auto-session/session-lens/init.lua
+++ b/lua/auto-session/session-lens/init.lua
@@ -14,6 +14,7 @@ local SessionLens = {
 ---@class session_lens_config
 ---@field shorten_path boolean
 ---@field theme_conf table
+---@field buftypes_to_ignore table
 ---@field previewer boolean
 ---@field session_control session_control
 ---@field load_on_setup boolean
@@ -22,6 +23,7 @@ local SessionLens = {
 local defaultConf = {
   theme_conf = { winblend = 10, border = true },
   previewer = false,
+  buftypes_to_ignore = {},
 }
 
 -- Set default config on plugin load


### PR DESCRIPTION
This `PR` should add functionality to avoid undesired buffer removal.

e.g. If you want to keep `terminal` buffer open and switch back and forth from one session to another session. it makes sense to keep it open.