### PR TITLE
Fix telescope extension

### DIFF
--- a/lua/telescope/_extensions/session-lens.lua
+++ b/lua/telescope/_extensions/session-lens.lua
@@ -7,5 +7,6 @@ return telescope.register_extension {
   end,
   exports = {
     search_session = SessionLens.search_session,
+    ["session-lens"] = SessionLens.search_session,
   },
 }


### PR DESCRIPTION
Runing the `:Telescope session-lens` command causes a 'attempt to call a nil value' error. This pull request fixes that.