### PR TITLE
feat: Add command to purge orphaned sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Auto Session exposes two commands that can be used or mapped to any keybindings 
 :SessionRestoreFromFile ~/session/path " restores any currently saved session
 :SessionDelete " deletes a session in the currently set `auto_session_root_dir`.
 :SessionDelete ~/my/custom/path " deleetes a session based on the provided path.
+:SessionPurgeOrphaned " removes all orphaned sessions with no working directory left.
 :Autosession search
 :Autosession delete
 ```

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -190,11 +190,12 @@ session_lens_config                                        *session_lens_config*
     Session Lens Config
 
     Fields: ~
-        {shorten_path}     (boolean)
-        {theme_conf}       (table)
-        {previewer}        (boolean)
-        {session_control}  (session_control)
-        {load_on_setup}    (boolean)
+        {shorten_path}        (boolean)
+        {theme_conf}          (table)
+        {buftypes_to_ignore}  (table)
+        {previewer}           (boolean)
+        {session_control}     (session_control)
+        {load_on_setup}       (boolean)
 
 
 SessionLens.setup()                                          *SessionLens.setup*

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -173,6 +173,10 @@ AutoSession.DeleteSession({...})                     *AutoSession.DeleteSession*
         {...}  (string[])
 
 
+AutoSession.PurgeOrphanedSessions()          *AutoSession.PurgeOrphanedSessions*
+    PurgeOrphanedSessions deletes sessions with no working directory exist
+
+
                                                               *M.setup_autocmds*
 M.setup_autocmds({config}, {AutoSession})
     Setup autocmds for DirChangedPre and DirChanged


### PR DESCRIPTION
Adds `:SessionPurgeOrphaned` and
`require('auto-session').PurgeOrphanedSessions()` commands to purge all sessions with non-existent working directories.

Fixes #232