### PR TITLE
Add session lens delete shortcut to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ vim.keymap.set("n", "<C-s>", require("auto-session.session-lens").search_session
 })
 ```
 
-*Note:* hitting `<C-s>` on an open session-lens picker will automatically try to restore the previous session opened. This can give you a nice flow if you're constantly switching between two projects.
+*Note:* hitting `<C-s>` on an open session-lens picker will automatically try to restore the previous session opened. This can give you a nice flow if you're constantly switching between two projects. Additionally, `<C-d>` will delete the currently selected session.
 
 Sometime after `telescope.nvim` has been started, you'll want to call `lua require("telescope").load_extension "session-lens"` so that command completion works for `:Telescope session-lens` commands.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ vim.keymap.set("n", "<C-s>", require("auto-session.session-lens").search_session
 })
 ```
 
-*Note:* hitting `<C-s>` on an open session-lens picker will automatically try to restore the previous session opened. This can give you a nice flow if you're constantly switching between two projects. Additionally, `<C-d>` will delete the currently selected session.
+*Note:* hitting `<C-s>` on an open session-lens picker will automatically try to restore the previous session opened. This can give you a nice flow if you're constantly switching between two projects. Additionally, `<C-d>` will delete the currently highlighted session.
 
 Sometime after `telescope.nvim` has been started, you'll want to call `lua require("telescope").load_extension "session-lens"` so that command completion works for `:Telescope session-lens` commands.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,9 @@ vim.keymap.set("n", "<C-s>", require("auto-session.session-lens").search_session
 })
 ```
 
-*Note:* hitting `<C-s>` on an open session-lens picker will automatically try to restore the previous session opened. This can give you a nice flow if you're constantly switching between two projects. Additionally, `<C-d>` will delete the currently highlighted session.
+The following shortcuts are available when the session-lens picker is open
+* `<c-s>` restores the previously opened session. This can give you a nice flow if you're constantly switching between two projects.
+* `<c-d>` will delete the currently highlighted session. This makes it easy to keep the session list clean.
 
 Sometime after `telescope.nvim` has been started, you'll want to call `lua require("telescope").load_extension "session-lens"` so that command completion works for `:Telescope session-lens` commands.
 


### PR DESCRIPTION
I was happy to find that there is a shortcut to delete sessions right within the session lens picker. Unfortunately, it is not mentioned anywhere in the readme. Specifically, I expected it to be listed with the session alternation shortcut, so that's where I suggest it is added.