### PR TITLE
Work around upstream issue executing shell commands on `VimLeave`

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -937,7 +937,7 @@ function SetupAutocmds()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "VimLeave" }, {
+  vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
     group = group,
     pattern = "*",
     callback = function()


### PR DESCRIPTION
Execute AutoSaveSession on VimLeavePre instead. Session save net functionality should remain the same.

Upstream issue:
https://github.com/neovim/neovim/issues/21856#issuecomment-1514723887

Fixes #268

Workaround inspired by:
https://github.com/mrjones2014/smart-splits.nvim/pull/159