### PR TITLE
Fix tried to close last window error

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -101,7 +101,7 @@ local luaOnlyConf = {
       control_filename = "session_control.json", -- File name of the session control file
     },
   },
-  silent_restore = true
+  silent_restore = true,
 }
 
 -- Set default config on plugin load
@@ -396,8 +396,11 @@ function AutoSession.AutoSaveSession(sessions_dir)
     end
 
     if AutoSession.conf.close_unsupported_windows then
-      -- Swallow errors as we may end up trying to close the last window
-      pcall(Lib.close_unsupported_windows)
+      -- Wrap in pcall in case there's an error while trying to close windows
+      local success, result = pcall(Lib.close_unsupported_windows)
+      if not success then
+        Lib.logger.debug("Error closing unsupported windows: " .. result)
+      end
     end
 
     AutoSession.SaveSession(sessions_dir, true)
@@ -857,7 +860,7 @@ function AutoSession.PurgeOrphanedSessions()
   local orphaned_sessions = {}
 
   for _, session in ipairs(AutoSession.get_session_files()) do
-    if session.display_name:find('^/.*') and vim.fn.isdirectory(session.display_name) == Lib._VIM_FALSE then
+    if session.display_name:find "^/.*" and vim.fn.isdirectory(session.display_name) == Lib._VIM_FALSE then
       table.insert(orphaned_sessions, session.display_name)
     end
   end

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -379,7 +379,7 @@ end
 -- This is useful for starter plugins which don't want to display 'restore session'
 -- unless a session for the current working directory exists.
 function AutoSession.session_exists_for_cwd()
-  session_file = get_session_file_name(vim.fn.getcwd())
+  local session_file = get_session_file_name(vim.fn.getcwd())
   return Lib.is_readable(session_file)
 end
 
@@ -396,7 +396,8 @@ function AutoSession.AutoSaveSession(sessions_dir)
     end
 
     if AutoSession.conf.close_unsupported_windows then
-      Lib.close_unsupported_windows()
+      -- Swallow errors as we may end up trying to close the last window
+      pcall(Lib.close_unsupported_windows)
     end
 
     AutoSession.SaveSession(sessions_dir, true)
@@ -907,7 +908,7 @@ function SetupAutocmds()
   vim.api.nvim_create_user_command(
     "SessionSave",
     SaveSession,
-    { bang = true, nargs = '?', desc = "Save the current session. Based in cwd if no arguments are passed" }
+    { bang = true, nargs = "?", desc = "Save the current session. Based in cwd if no arguments are passed" }
   )
 
   vim.api.nvim_create_user_command("SessionRestore", SessionRestore, { bang = true, desc = "Restore Session" })

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -190,11 +190,14 @@ function Lib.close_unsupported_windows()
   for _, tabpage in ipairs(tabpages) do
     local windows = vim.api.nvim_tabpage_list_wins(tabpage)
     for _, window in ipairs(windows) do
+      -- Never try to close the last window of the last tab
+      if vim.fn.tabpagenr "$" == 1 and vim.fn.winnr "$" == 1 then
+        return
+      end
       local buffer = vim.api.nvim_win_get_buf(window)
       local file_name = vim.api.nvim_buf_get_name(buffer)
       if not Lib.is_readable(file_name) then
         vim.api.nvim_win_close(window, true)
-        break
       end
     end
   end

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -194,7 +194,7 @@ function Lib.close_unsupported_windows()
       local file_name = vim.api.nvim_buf_get_name(buffer)
       if not Lib.is_readable(file_name) then
         vim.api.nvim_win_close(window, true)
-        break;
+        break
       end
     end
   end


### PR DESCRIPTION
Easiest repro is only have a new buffer (not saved to a file) and exit. We'll  try to close that window and generate an error.

To fix, we wrap `Lib.close_unsupported_windows` in a `pcall`. In general, not great to eat all errors but we're making our best effort to close all of the unsupported windows and there are a bunch of edge cases there so this seems like the most reasonable path to me.

Also added a missiing local