### PR TITLE
Fix for #299

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,26 +284,33 @@ For troubleshooting refer to the [wiki page](https://github.com/rmagatti/auto-se
 
 ## 🔭 Session Lens
 
-Session Lens has been merged into Auto Session! This means all the functionality of Session Lens is now available in Auto Session.
-
-You still need to call the session-lens specific setup function for things to work properly since even though these plugins are now merged, they are effectively fully modular and auto-session does not depend on session-lens functionality.
+Session Lens has been merged into Auto Session! This means all the functionality of Session Lens is now available in Auto Session. It's enabled by
+default if you have Telescope, but here's the Lazy config that shows the configuration options:  
 
 ```lua
-require("auto-session").setup {
-  log_level = vim.log.levels.ERROR,
-  auto_session_suppress_dirs = { "~/", "~/Projects", "~/Downloads", "/" },
-  auto_session_use_git_branch = false,
 
-  auto_session_enable_last_session = false,
+return {
+  {
+    'rmagatti/auto-session',
+    dependencies = {
+      'nvim-telescope/telescope.nvim',
+    },
+    config = function()
+      require('auto-session').setup({
+        log_level = 'error',
+        auto_session_suppress_dirs = { '~/', '~/Projects', '~/Downloads', '/' },
 
-  -- ⚠️ This will only work if Telescope.nvim is installed
-  -- The following are already the default values, no need to provide them if these are already the settings you want.
-  session_lens = {
-    -- If load_on_setup is set to false, one needs to eventually call `require("auto-session").setup_session_lens()` if they want to use session-lens.
-    buftypes_to_ignore = {}, -- list of buffer types what should not be deleted from current session
-    load_on_setup = true,
-    theme_conf = { border = true },
-    previewer = false,
+        -- ⚠️ This will only work if Telescope.nvim is installed
+        -- The following are already the default values, no need to provide them if these are already the settings you want.
+        session_lens = {
+          -- If load_on_setup is set to false, one needs to eventually call `require("auto-session").setup_session_lens()` if they want to use session-lens.
+          load_on_setup = true,
+          theme_conf = { border = true },
+          previewer = false,
+          buftypes_to_ignore = {}, -- list of buffer types that should not be deleted from current session when a new one is loaded
+        },
+      })
+    end,
   },
 }
 
@@ -314,11 +321,13 @@ vim.keymap.set("n", "<C-s>", require("auto-session.session-lens").search_session
 })
 ```
 
+You can also use `:Telescope session-lens` to launch the session picker.
+
 The following shortcuts are available when the session-lens picker is open
 * `<c-s>` restores the previously opened session. This can give you a nice flow if you're constantly switching between two projects.
 * `<c-d>` will delete the currently highlighted session. This makes it easy to keep the session list clean.
 
-Sometime after `telescope.nvim` has been started, you'll want to call `lua require("telescope").load_extension "session-lens"` so that command completion works for `:Telescope session-lens` commands.
+NOTE: If you previously installed `rmagatti/session-lens`, you should remove it from your config as it is no longer necessary.
 
 Auto Session provides its own `:Autosession search` and `:Autosession delete` commands, but session-lens is a more complete version of those commands that is specifically built to be used with `telescope.nvim`. These commands make use of `vim.ui.select` which can itself be implemented by other plugins other than telescope.
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -132,7 +132,7 @@ function AutoSession.setup(config)
 end
 
 function AutoSession.setup_session_lens()
-  local has_telescope, _ = pcall(require, "telescope")
+  local has_telescope, telescope = pcall(require, "telescope")
 
   if not has_telescope then
     Lib.logger.info "Telescope.nvim is not installed. Session Lens cannot be setup!"
@@ -140,6 +140,8 @@ function AutoSession.setup_session_lens()
   end
 
   require("auto-session.session-lens").setup(AutoSession)
+  -- Register session-lens as an extension so :Telescope will complete on session-lens
+  telescope.load_extension "session-lens"
 end
 
 local function is_enabled()
@@ -508,6 +510,8 @@ local function handle_autosession_command(data)
   if data.args:match "search" then
     open_picker(files, "Select a session:", function(choice)
       -- Change dir to selected session path, the DirChangePre and DirChange events will take care of the rest
+      -- BUG: The above is only true if cwd_change_handling is true which means sessions
+      -- won't be restored if cwd_change_handling is false
       vim.fn.chdir(choice.display_name)
     end)
   elseif data.args:match "delete" then

--- a/lua/auto-session/session-lens/actions.lua
+++ b/lua/auto-session/session-lens/actions.lua
@@ -39,16 +39,18 @@ local function source_session(selection, prompt_bufnr)
   end
 
   vim.defer_fn(function()
-    if -- type(AutoSession.conf.cwd_change_handling) == "table"
-      -- and not vim.tbl_isempty(AutoSession.conf.cwd_change_handling or {})
-      -- and AutoSession.conf.cwd_change_handling.restore_upcoming_session
-      -- FIXME: Trying to check if cwd_change_handling properties are set, but something is wrong here.
-      false
-    then
+    local cwd_change_handling_conf = M.functions.conf.cwd_change_handling
+
+    -- If cwd_change_handling is true, the current session will be saved in the DirChangedPre AutoCmd
+    -- and the new session will be restored in DirChanged
+    if type(cwd_change_handling_conf) == "table" and cwd_change_handling_conf.restore_upcoming_session then
       -- Take advatage of cwd_change_handling behaviour for switching sessions
       Lib.logger.debug "Triggering vim.fn.chdir since cwd_change_handling feature is enabled"
       vim.fn.chdir(M.functions.format_file_name(type(selection) == "table" and selection.filename or selection))
     else
+      -- TODO: Since cwd_change_handling is disabled, we save and restore here. This would probably be better
+      -- handled in AutoSession itself since the same case comes up if the built in picker is used
+      -- (e.g. :Autosession search).
       Lib.logger.debug "Triggering session-lens behaviour since cwd_change_handling feature is disabled"
       M.functions.AutoSaveSession()
 

--- a/lua/auto-session/session-lens/init.lua
+++ b/lua/auto-session/session-lens/init.lua
@@ -12,7 +12,8 @@ local SessionLens = {
 
 ---Session Lens Config
 ---@class session_lens_config
----@field shorten_path boolean
+---@field shorten_path boolean Deprecated, pass { 'shorten' } to path_display
+---@field path_display table An array that specifies how to handle paths. Read :h telescope.defaults.path_display
 ---@field theme_conf table
 ---@field buftypes_to_ignore table
 ---@field previewer boolean


### PR DESCRIPTION
Fix the conf checks in session-lens/actions.lua to handle the case where cwd_change_handling is true.

The original bug report includes a config for when session lens was in a separate repo and that confused me for a bit so I tried to make the documentation more clear.

Also, added the Telescope load_extension call in setup_session_lens so users don't have to.

Lastly, I think there's a bug with the built-in picker (:Autosession search) where it won't load the session if cwd_change_handling is false. I did not address that in this PR but left a BUG: marker.