### PR TITLE
ensure json is decoded correctly even if it's content is multiline

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -621,7 +621,8 @@ local function write_to_session_control_json(session_file_name)
   local session_control_file = control_dir .. control_file
 
   local log_ending_state = function()
-    local content = vim.fn.readfile(session_control_file)
+    local file_lines = vim.fn.readfile(session_control_file)
+    local content = table.concat(file_lines, " ")
     local session_control = vim.json.decode(content[1] or "{}") or {}
     local sessions = { current = session_control.current, alternate = session_control.alternate }
 
@@ -629,7 +630,8 @@ local function write_to_session_control_json(session_file_name)
   end
 
   if vim.fn.filereadable(session_control_file) == 1 then
-    local content = vim.fn.readfile(session_control_file)
+    local file_lines = vim.fn.readfile(session_control_file)
+    local content = table.concat(file_lines, " ")
     Lib.logger.debug { content = content }
     local json = vim.json.decode(content[1] or "{}") or {}
 


### PR DESCRIPTION
I had an issue on Windows where I was getting the following error when restoring session:
```
Error detected while processing VimEnter Autocommands for "*":
Error executing lua callback: ...l/share/nvim/lazy/auto-session/lua/auto-session/init.lua:634: Expected object key string but found T_END at character 2
stack traceback:
        [C]: in function 'decode'
        ...l/share/nvim/lazy/auto-session/lua/auto-session/init.lua:634: in function 'write_to_session_control_json'
        ...l/share/nvim/lazy/auto-session/lua/auto-session/init.lua:757: in function 'restore'
        ...l/share/nvim/lazy/auto-session/lua/auto-session/init.lua:799: in function 'AutoRestoreSession'
        ...l/share/nvim/lazy/auto-session/lua/auto-session/init.lua:1038: in function <...l/share/nvim/lazy/auto-session/lua/auto-session/init.lua:1012>
Press ENTER or type command to continue
```

I replicated it on macOS as well, the problem was that the inside `nvim-data` folder the  `auto_session/session_;control.json` file was not written as a single line so:

```json
{"current":"some-path","alternate":"some-path"}
```

but for some reason it got formatted to


```json
{
    "current": "some-path",
    "alternate": "some-path"
}
```

 which broke:

```lua
vim.json.decode(content[1] or "{}")
```

because `content[1]` was now just equal to `"{"` so it wasn't a valid `JSON` format, but it was truthy.

My fix is making sure that even if the file was broken into several lines, it will be again concatenated into a single string and then this single string will be parsed as a JSON.