### PR TITLE
Do not throw and return early when this_session is nil

### DIFF
--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -32,6 +32,9 @@ end
 -- because they have dashes in the name
 function Lib.current_session_name()
   local fname = Lib.get_file_name(vim.v.this_session)
+  if fname == nil or fname == '' then
+    return ""
+  end
   local extension = Lib.get_file_extension(fname)
   local fname_without_extension = fname:gsub(extension:gsub("%.", "%%%.") .. "$", "")
   local fname_split = vim.split(fname_without_extension, "%%")


### PR DESCRIPTION
### Describe the bug
I'm using `auto-session` with `tabby` using the `current_session_name()` API.

When I open any file in a directory with no associated sessions, `current_session_name()` function throws an error.

### To reproduce
Go to a directory with no previous sessions.
Open a file using `nvim test.txt`
Get the following error:
```
E5108: Error executing lua ...al/share/nvim/lazy/auto-session/lua/auto-session/lib.lua:28: attempt to index l
ocal 'url' (a nil value)
stack traceback:
        ...al/share/nvim/lazy/auto-session/lua/auto-session/lib.lua:28: in function 'get_file_extension'
        ...al/share/nvim/lazy/auto-session/lua/auto-session/lib.lua:38: in function 'current_session_name'
        /home/.../projects/dotfiles/nvim/after/plugin/tabby.lua:34: in function 'fn'
        .../.local/share/nvim/lazy/tabby.nvim/lua/tabby/tabline.lua:51: in function 'render'
        [string "luaeval()"]:1: in main chunk
```

### Baseline
* `set sessionoptions?`:  sessionoptions=blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions
* `uname -a`:
> Linux xxx 6.8.0-38-generic #\38-Ubuntu SMP PREEMPT_DYNAMIC Fri Jun  7 15:25:01 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
* Neovim version:
> NVIM v0.10.0
> Build type: Release
> LuaJIT 2.1.1713484068


### Changes
I -unsuccessfully- tried to mitigate the error on my side using
```
    local autosession = require('auto-session.lib').current_session_name()
    local sessionname_found, sessionname = pcall(autosession, "current_session_name")
    if not sessionname_found then
      sessionname = ''
    end
```
but that did not address the error I'm seeing at the start up.

Changes in this PR resolve this issue.