### PR TITLE
Keep sourcing the session even if there's an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ require("auto-session").setup {
   },
   args_allow_single_directory = true, -- boolean Follow normal sesion save/load logic if launched with a single directory as the only argument
   args_allow_files_auto_save = false, -- boolean|function Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not load any existing session first. While you can just set this to true, you probably want to set it to a function that decides when to save a session when launched with file args. See documentation for more detail
+  silent_restore = true, -- Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number a restore error
 }
 ```
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -22,7 +22,7 @@ luaOnlyConf                                                        *luaOnlyConf*
         {cwd_change_handling?}             (boolean|CwdChangeHandling)
         {bypass_session_save_file_types?}  (table)                      List of file types to bypass auto save when the only buffer open is one of the file types listed
         {close_unsupported_windows?}       (boolean)                    Whether to close windows that aren't backed by a real file
-        {silent_restore?}                  (boolean)                    Whether to restore sessions silently or not
+        {silent_restore?}                  (boolean)                    Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number of a restore error
         {log_level?}                       (string|integer)             "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
         {args_allow_single_directory?}     (boolean)                    Follow normal sesion save/load logic if launched with a single directory as the only argument
                                                                         Argv Handling

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -74,7 +74,7 @@ local defaultConf = {
 ---@field cwd_change_handling? boolean|CwdChangeHandling
 ---@field bypass_session_save_file_types? table List of file types to bypass auto save when the only buffer open is one of the file types listed
 ---@field close_unsupported_windows? boolean Whether to close windows that aren't backed by a real file
----@field silent_restore? boolean Whether to restore sessions silently or not
+---@field silent_restore? boolean Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number of a restore error
 ---@field log_level? string|integer "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
 ---Argv Handling
 ---@field args_allow_single_directory? boolean Follow normal sesion save/load logic if launched with a single directory as the only argument
@@ -114,7 +114,7 @@ local luaOnlyConf = {
       control_filename = "session_control.json", -- File name of the session control file
     },
   },
-  silent_restore = true,
+  silent_restore = true, --  Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number of a restore error
 }
 
 -- Set default config on plugin load


### PR DESCRIPTION
Still show the last error at the end (if there is one). Setting `silent_restore` to `false` will restore the current behavior of stopping at the first error.

Improves #325
Fixes #337