### PR TITLE
fix: #286 for legacy session file names

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -482,6 +482,12 @@ end
 ---@return boolean True if a session exists for the cwd
 function AutoSession.session_exists_for_cwd()
   local session_file = get_session_file_name(vim.fn.getcwd())
+  if vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0 then
+    return true
+  end
+
+  -- Check legacy sessions
+  local session_file = get_session_file_name(vim.fn.getcwd(), true)
   return vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0
 end
 

--- a/tests/cmds_spec.lua
+++ b/tests/cmds_spec.lua
@@ -17,6 +17,7 @@ describe("The default config", function()
   end)
 
   it("can save a session for the cwd", function()
+    assert.False(as.session_exists_for_cwd())
     vim.cmd("e " .. TL.test_file)
 
     vim.cmd "SessionSave"

--- a/tests/legacy_file_names_spec.lua
+++ b/tests/legacy_file_names_spec.lua
@@ -25,6 +25,8 @@ describe("Legacy file name support", function()
 
     -- save a default session in new format
     as.SaveSession()
+
+    assert.True(as.session_exists_for_cwd())
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
     assert.equals(1, vim.fn.filereadable(default_extra_cmds_path))
 
@@ -32,6 +34,7 @@ describe("Legacy file name support", function()
     vim.loop.fs_rename(default_extra_cmds_path, legacy_extra_cmds_path)
 
     print(TL.default_session_path_legacy)
+    assert.True(as.session_exists_for_cwd())
     assert.equals(1, vim.fn.filereadable(TL.default_session_path_legacy))
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))
     assert.equals(1, vim.fn.filereadable(legacy_extra_cmds_path))
@@ -54,6 +57,8 @@ describe("Legacy file name support", function()
     -- and no old file name?
     assert.equals(0, vim.fn.filereadable(TL.default_session_path_legacy))
     assert.equals(0, vim.fn.filereadable(legacy_extra_cmds_path))
+
+    assert.True(as.session_exists_for_cwd())
   end)
 
   it("can convert a session to the new format during a delete", function()


### PR DESCRIPTION
Forgot to check for legacy session names in `session_exists_for_cwd`