### PR TITLE
Don't try to autosave a session for the same directory we're loading from. Also customizable keymaps for session lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ You can use Telescope to see, load, and delete your sessions. It's enabled by de
         load_on_setup = true,
         theme_conf = { border = true },
         previewer = false,
+        mappings = {
+          -- Mode can be a string or a table, e.g. {"i", "n"} for both insert and normal mode
+          delete_session = { "i", "<C-D>" },
+          alternate_session = { "i", "<C-S>" },
+        },
       },
     })
   end,

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ EOF
 
 ```lua
 require("auto-session").setup {
-  bypass_session_save_file_types = nil, -- table: Bypass auto save when only buffer open is one of these file types
+  bypass_session_save_file_types = nil, -- table: Bypass auto save when only buffer open is one of these file types, useful to ignore dashboards
   close_unsupported_windows = true, -- boolean: Close windows that aren't backed by normal file
   cwd_change_handling = { -- table: Config for handling the DirChangePre and DirChanged autocmds, can be set to nil to disable altogether
     restore_upcoming_session = false, -- boolean: restore session for upcoming cwd on cwd change
@@ -433,6 +433,17 @@ require('lualine').setup{
 ```
 
 <img width="1904" alt="Screen Shot 2021-10-30 at 3 58 57 PM" src="https://user-images.githubusercontent.com/2881382/139559478-8edefdb8-8254-42e7-a0f3-babd3dfd6ff2.png">
+
+## Dashboards
+
+If you use a dashboard, you probably don't want to try and save a session when just the dashboard is open. To avoid that, add your dashboard filetype to the bypass list as follows:
+
+```lua
+require('auto-session').setup({
+  bypass_session_save_file_types = { 'alpha', 'dashboard' } -- or whatever dashboard you use
+})
+
+```
 
 ## Disabling the plugin
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -39,12 +39,34 @@ CwdChangeHandling                                            *CwdChangeHandling*
         {post_cwd_changed_hook?}    (boolean)  {true} This is called after auto_session code runs for the DirChanged autocmd
 
 
+session_lens_config                                        *session_lens_config*
+    Session Lens Config
+
+    Fields: ~
+        {load_on_setup?}       (boolean)
+        {shorten_path?}        (boolean)               Deprecated, pass { 'shorten' } to path_display
+        {path_display?}        (table)                 An array that specifies how to handle paths. Read :h telescope.defaults.path_display
+        {theme_conf?}          (table)
+        {buftypes_to_ignore?}  (table)                 Deprecated, if you're using this please report your usage on github
+        {previewer?}           (boolean)
+        {session_control?}     (session_control)
+        {mappings?}            (session_lens_mapping)
+
+
 session_control                                                *session_control*
     Session Control Config
 
     Fields: ~
         {control_dir}       (string)
         {control_filename}  (string)
+
+
+session_lens_mapping                                      *session_lens_mapping*
+    Session Lens Mapping
+
+    Fields: ~
+        {delete_session}     (table)  mode and key for deleting a session from the picker
+        {alternate_session}  (table)  mode and key for swapping to alertnate session from the picker
 
 
 AutoSession.setup({config})                                  *AutoSession.setup*
@@ -185,19 +207,6 @@ AutoSession.DisableAutoSave({enable?})             *AutoSession.DisableAutoSave*
 
     Returns: ~
         (boolean)  autosaving is enabled or not
-
-
-session_lens_config                                        *session_lens_config*
-    Session Lens Config
-
-    Fields: ~
-        {shorten_path?}        (boolean)          Deprecated, pass { 'shorten' } to path_display
-        {path_display?}        (table)            An array that specifies how to handle paths. Read :h telescope.defaults.path_display
-        {theme_conf?}          (table)
-        {buftypes_to_ignore?}  (table)            Deprecated, if you're using this please report your usage on github
-        {previewer?}           (boolean)
-        {session_control?}     (session_control)
-        {load_on_setup?}       (boolean)
 
 
 SessionLens.setup()                                          *SessionLens.setup*

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -20,7 +20,7 @@ luaOnlyConf                                                        *luaOnlyConf*
 
     Fields: ~
         {cwd_change_handling?}             (boolean|CwdChangeHandling)
-        {bypass_session_save_file_types?}  (table)                      List of file types to bypass auto save when the only buffer open is one of the file types listed
+        {bypass_session_save_file_types?}  (table)                      List of file types to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
         {close_unsupported_windows?}       (boolean)                    Whether to close windows that aren't backed by a real file
         {silent_restore?}                  (boolean)                    Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number of a restore error
         {log_level?}                       (string|integer)             "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -487,7 +487,7 @@ function AutoSession.session_exists_for_cwd()
   end
 
   -- Check legacy sessions
-  local session_file = get_session_file_name(vim.fn.getcwd(), true)
+  session_file = get_session_file_name(vim.fn.getcwd(), true)
   return vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0
 end
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -100,18 +100,40 @@ local luaOnlyConf = {
   ---   post_cwd_changed_hook = nil, -- lua function hook. This is called after auto_session code runs for the `DirChanged` autocmd
   --- }
   cwd_change_handling = false,
+
+  ---Session Lens Config
+  ---@class session_lens_config
+  ---@field load_on_setup? boolean
+  ---@field shorten_path? boolean Deprecated, pass { 'shorten' } to path_display
+  ---@field path_display? table An array that specifies how to handle paths. Read :h telescope.defaults.path_display
+  ---@field theme_conf? table
+  ---@field buftypes_to_ignore? table Deprecated, if you're using this please report your usage on github
+  ---@field previewer? boolean
+  ---@field session_control? session_control
+  ---@field mappings? session_lens_mapping
+
   ---Session Control Config
   ---@class session_control
   ---@field control_dir string
   ---@field control_filename string
 
+  ---Session Lens Mapping
+  ---@class session_lens_mapping
+  ---@field delete_session table mode and key for deleting a session from the picker
+  ---@field alternate_session table mode and key for swapping to alertnate session from the picker
+
   ---@type session_lens_config
   session_lens = {
-    buftypes_to_ignore = {}, -- list of bufftypes to ignore when switching between sessions
     load_on_setup = true,
+    buftypes_to_ignore = {},
     session_control = {
       control_dir = vim.fn.stdpath "data" .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
       control_filename = "session_control.json", -- File name of the session control file
+    },
+    mappings = {
+      -- Mode can be a string or a table, e.g. {"i", "n"} for both insert and normal mode
+      delete_session = { "i", "<C-D>" },
+      alternate_session = { "i", "<C-S>" },
     },
   },
   silent_restore = true, --  Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number of a restore error

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -648,11 +648,19 @@ end
 
 ---@private
 ---Handler for when a session is picked from the UI, either via Telescope or via AutoSession.select_session
----Save the current session (if autosave allows) and restore the selected session
+---Save the current session if the session we're loading isn't also for the cwd (if autosave allows)
+---and then restore the selected session
 ---@param session_name string The session name to restore
 ---@return boolean Was the session restored successfully
 function AutoSession.autosave_and_restore(session_name)
-  AutoSession.AutoSaveSession()
+  local cwd_session_name = Lib.escaped_session_name_to_session_name(get_session_file_name())
+  if cwd_session_name ~= session_name then
+    Lib.logger.debug("Autosaving before restoring", { cwd = cwd_session_name, session_name = session_name })
+    AutoSession.AutoSaveSession()
+  else
+    Lib.logger.debug("Not autosaving, cwd == session_name for: ", session_name)
+  end
+
   return AutoSession.RestoreSession(session_name)
 end
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -72,7 +72,7 @@ local defaultConf = {
 ---Lua Only Configs for Auto Session
 ---@class luaOnlyConf
 ---@field cwd_change_handling? boolean|CwdChangeHandling
----@field bypass_session_save_file_types? table List of file types to bypass auto save when the only buffer open is one of the file types listed
+---@field bypass_session_save_file_types? table List of file types to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
 ---@field close_unsupported_windows? boolean Whether to close windows that aren't backed by a real file
 ---@field silent_restore? boolean Suppress extraneous messages and source the whole session, even if there's an error. Set to false to get the line number of a restore error
 ---@field log_level? string|integer "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
@@ -82,7 +82,7 @@ local defaultConf = {
 ---@field session_lens? session_lens_config Session lens configuration options
 
 local luaOnlyConf = {
-  bypass_session_save_file_types = nil, -- Bypass auto save when only buffer open is one of these file types
+  bypass_session_save_file_types = nil, -- Bypass auto save when only buffer open is one of these file types, useful to ignore dashboards
   close_unsupported_windows = true, -- Close windows that aren't backed by normal file
   args_allow_single_directory = true, -- Allow single directory arguments by default
   args_allow_files_auto_save = false, -- Don't save session for file args by default

--- a/lua/auto-session/session-lens/init.lua
+++ b/lua/auto-session/session-lens/init.lua
@@ -7,28 +7,8 @@ local SessionLens = {
   conf = {},
 }
 
----Session Lens Config
----@class session_lens_config
----@field shorten_path? boolean Deprecated, pass { 'shorten' } to path_display
----@field path_display? table An array that specifies how to handle paths. Read :h telescope.defaults.path_display
----@field theme_conf? table
----@field buftypes_to_ignore? table Deprecated, if you're using this please report your usage on github
----@field previewer? boolean
----@field session_control? session_control
----@field load_on_setup? boolean
-
----@type session_lens_config
-local defaultConf = {
-  theme_conf = {},
-  previewer = false,
-  buftypes_to_ignore = {},
-}
-
--- Set default config on plugin load
-SessionLens.conf = defaultConf
-
 function SessionLens.setup()
-  SessionLens.conf = vim.tbl_deep_extend("force", SessionLens.conf, AutoSession.conf.session_lens)
+  SessionLens.conf = AutoSession.conf.session_lens
 
   if SessionLens.conf.buftypes_to_ignore ~= nil and not vim.tbl_isempty(SessionLens.conf.buftypes_to_ignore) then
     Lib.logger.warn "buftypes_to_ignore is deprecated. If you think you need this option, please file a bug on GitHub. If not, please remove it from your config"
@@ -131,9 +111,12 @@ SessionLens.search_session = function(custom_opts)
     cwd = session_root_dir,
     attach_mappings = function(_, map)
       telescope_actions.select_default:replace(Actions.source_session)
-      map("i", "<c-d>", Actions.delete_session)
-      map("i", "<c-s>", Actions.alternate_session)
-      map("i", "<c-a>", Actions.alternate_session)
+
+      local mappings = AutoSession.conf.session_lens.mappings
+      if mappings then
+        map(mappings.delete_session[1], mappings.delete_session[2], Actions.delete_session)
+        map(mappings.alternate_session[1], mappings.alternate_session[2], Actions.alternate_session)
+      end
       return true
     end,
   }


### PR DESCRIPTION
Partially fixes #344 (but it's still better to ignore dashboards in the config)

Also add a quick section in docs about dashboards