### PR TITLE
fix: don't create empty extra command files

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -344,7 +344,7 @@ end
 ---@private
 ---Get the hook commands from the config and run them
 ---@param hook_name string
----@return table Results of the commands
+---@return table|nil Results of the commands
 function AutoSession.run_cmds(hook_name)
   local cmds = Config[hook_name .. "_cmds"]
   return Lib.run_hook_cmds(cmds, hook_name)

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -536,13 +536,13 @@ end
 
 ---@param cmds table Cmds to run
 ---@param hook_name string Name of the hook being run
----@return table Results of the cmds
+---@return table|nil Results of the cmds
 function Lib.run_hook_cmds(cmds, hook_name)
-  local results = {}
   if Lib.is_empty_table(cmds) then
-    return results
+    return nil
   end
 
+  local results = {}
   for _, cmd in ipairs(cmds) do
     Lib.logger.debug(string.format("Running %s command: %s", hook_name, cmd))
     local success, result

--- a/lua/auto-session/session-lens/init.lua
+++ b/lua/auto-session/session-lens/init.lua
@@ -125,15 +125,11 @@ SessionLens.search_session = function(custom_opts)
       end
       return opts.find_command
     elseif 1 == vim.fn.executable "rg" then
-      return { "rg", "--files", "--color", "never" }
-    elseif 1 == vim.fn.executable "fd" then
-      return { "fd", "--type", "f", "--color", "never" }
-    elseif 1 == vim.fn.executable "fdfind" then
-      return { "fdfind", "--type", "f", "--color", "never" }
-    elseif 1 == vim.fn.executable "ls" and vim.fn.has "win32" == 0 then
-      return { "ls" }
+      return { "rg", "--files", "--color", "never", "--sortr", "modified" }
+    elseif 1 == vim.fn.executable "ls" then
+      return { "ls", "-t" }
     elseif 1 == vim.fn.executable "cmd" and vim.fn.has "win32" == 1 then
-      return { "cmd", "/C", "dir", "/b" }
+      return { "cmd", "/C", "dir", "/b", "/o-d" }
     end
   end)()
 

--- a/tests/cmds_spec.lua
+++ b/tests/cmds_spec.lua
@@ -30,6 +30,10 @@ describe("The default config", function()
     -- Make sure the session has our buffer
     TL.assertSessionHasFile(TL.default_session_path, TL.test_file)
     assert.True(as.session_exists_for_cwd())
+
+    -- Make sure there isn't an extra commands file by default
+    local default_extra_cmds_path = TL.default_session_path:gsub("%.vim$", "x.vim")
+    assert.equals(0, vim.fn.filereadable(default_extra_cmds_path))
   end)
 
   it("can restore a session for the cwd", function()


### PR DESCRIPTION
Noticed that it was creating empty extra command files after my changes due to an empty table vs nil mistake. Only place that uses the return is in `save_extra_cmds_new` and it relies on the return being nil when there are no commands.

Also made picker sort by modified as the default rather than leaving it up to whatever the underlying command decided it should sort by (or no sort at all). Having a consistent, reasonable default seems better.