### PR TITLE
fix: return nil in session lens entry maker

### DIFF
--- a/lua/auto-session/session-lens/init.lua
+++ b/lua/auto-session/session-lens/init.lua
@@ -20,11 +20,7 @@ function SessionLens.make_telescope_callback(opts)
     -- Don't include <session>x.vim files that nvim makes for custom user
     -- commands
     if not Lib.is_session_file(session_root_dir .. file_name) then
-      -- FIXME: Returning nil would be better here since otherwise the result count
-      -- will be off. However, returning nil can prevent delete from working so return {}
-      -- until this is fixed:
-      -- https://github.com/nvim-telescope/telescope.nvim/issues/3265
-      return {}
+      return nil
     end
 
     -- the name of the session, to be used for restoring/deleting


### PR DESCRIPTION
Telescope merged my fix for:
https://github.com/nvim-telescope/telescope.nvim/issues/3265

So now we can return nil to have a correct count and still have delete sessions from the Telescope picker work