### PR TITLE
feat: autosave manually named sessions,  #386

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ AutoSession exposes the following commands that can be used or mapped to any key
 :Autosession delete " open a vim.ui.select picker to choose a session to delete.
 ```
 
+If you create a manually named session via `SessionSave my_session` or you restore one, that same session will be auto-saved (assuming that's enabled) when you exit.
+
 # 📖 More Configuration Details
 
 ## 🔭 Session Lens

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -298,8 +298,16 @@ function AutoSession.AutoSaveSession()
     return false
   end
 
+  -- If there's a manually named session, use that on exit instead of one named for cwd
+  local current_session = nil
+
+  if AutoSession.manually_named_session then
+    current_session = Lib.escaped_session_name_to_session_name(vim.fn.fnamemodify(vim.v.this_session, ":t"))
+    Lib.logger.debug("Using existing session name: " .. current_session)
+  end
+
   if not is_auto_create_enabled() then
-    local session_file_name = get_session_file_name()
+    local session_file_name = get_session_file_name(current_session)
     if vim.fn.filereadable(AutoSession.get_root_dir() .. session_file_name) == 0 then
       Lib.logger.debug "Create not enabled and no existing session, not creating session"
       return false
@@ -312,13 +320,6 @@ function AutoSession.AutoSaveSession()
     if not success then
       Lib.logger.debug("Error closing unsupported windows: " .. result)
     end
-  end
-
-  -- If there's a manually named session, use that on exit instead of one named for cwd
-  local current_session = nil
-  if AutoSession.manually_named_session then
-    current_session = Lib.escaped_session_name_to_session_name(vim.fn.fnamemodify(vim.v.this_session, ":t"))
-    Lib.logger.debug("Using existing session name: " .. current_session)
   end
 
   -- Don't try to show a message as we're exiting

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -314,8 +314,15 @@ function AutoSession.AutoSaveSession()
     end
   end
 
+  -- If there's a manually named session, use that on exit instead of one named for cwd
+  local current_session = nil
+  if AutoSession.manually_named_session then
+    current_session = Lib.escaped_session_name_to_session_name(vim.fn.fnamemodify(vim.v.this_session, ":t"))
+    Lib.logger.debug("Using existing session name: " .. current_session)
+  end
+
   -- Don't try to show a message as we're exiting
-  return AutoSession.SaveSession(nil, false)
+  return AutoSession.SaveSession(current_session, false)
 end
 
 ---@private
@@ -526,6 +533,18 @@ function AutoSession.SaveSessionToDir(session_dir, session_name, show_message)
 
   Lib.logger.debug("SaveSessionToDir escaped session name: " .. escaped_session_name)
 
+  -- If a session_name was passed in and it's different than the one for
+  -- the cwd, we know it's a manually named session. We track that so we
+  -- can write to that session on exit
+  if session_name then
+    local cwd_escaped_session_name = get_session_file_name(nil)
+
+    if escaped_session_name ~= cwd_escaped_session_name then
+      AutoSession.manually_named_session = true
+      Lib.logger.debug "Session is manually named"
+    end
+  end
+
   local session_path = session_dir .. escaped_session_name
 
   AutoSession.run_cmds "pre_save"
@@ -580,6 +599,18 @@ function AutoSession.RestoreSessionFromDir(session_dir, session_name, show_messa
   Lib.logger.debug("RestoreSessionFromDir escaped session name: " .. escaped_session_name)
 
   local session_path = session_dir .. escaped_session_name
+
+  -- If a session_name was passed in and it's different than the one for
+  -- the cwd, we know it's a manually named session. We track that so we
+  -- can write to that session on exit
+  if session_name then
+    local cwd_escaped_session_name = get_session_file_name(nil)
+
+    if escaped_session_name ~= cwd_escaped_session_name then
+      AutoSession.manually_named_session = true
+      Lib.logger.debug "Session is manually named"
+    end
+  end
 
   if vim.fn.filereadable(session_path) ~= 1 then
     Lib.logger.debug("RestoreSessionFromDir session does not exist: " .. session_path)

--- a/tests/manually_named_autosave_spec.lua
+++ b/tests/manually_named_autosave_spec.lua
@@ -2,7 +2,7 @@
 local TL = require "tests/test_lib"
 
 describe("Manually named sessions", function()
-  require("auto-session").setup {}
+  require("auto-session").setup { auto_create = false }
 
   it("can autosave", function()
     TL.clearSessionFilesAndBuffers()

--- a/tests/manually_named_autosave_spec.lua
+++ b/tests/manually_named_autosave_spec.lua
@@ -1,0 +1,41 @@
+---@diagnostic disable: undefined-field
+local TL = require "tests/test_lib"
+
+describe("Manually named sessions", function()
+  require("auto-session").setup {}
+
+  it("can autosave", function()
+    TL.clearSessionFilesAndBuffers()
+    vim.cmd("e " .. TL.test_file)
+
+    require("auto-session").SaveSession(TL.named_session_name)
+
+    vim.cmd("e " .. TL.other_file)
+
+    require("auto-session").AutoSaveSession()
+
+    -- Make sure the session was not created
+    assert.equals(0, vim.fn.filereadable(TL.default_session_path))
+    assert.equals(1, vim.fn.filereadable(TL.named_session_path))
+    TL.assertSessionHasFile(TL.named_session_path, TL.test_file)
+    TL.assertSessionHasFile(TL.named_session_path, TL.other_file)
+  end)
+
+  it("autosaving doesn't break normal autosaving", function()
+    TL.clearSessionFilesAndBuffers()
+    vim.cmd("e " .. TL.test_file)
+
+    require("auto-session").SaveSession()
+
+    vim.cmd("e " .. TL.other_file)
+    assert.equals(1, vim.fn.bufexists(TL.other_file))
+
+    require("auto-session").AutoSaveSession()
+
+    -- Make sure the session was not created
+    assert.equals(0, vim.fn.filereadable(TL.named_session_path))
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+    TL.assertSessionHasFile(TL.default_session_path, TL.test_file)
+    TL.assertSessionHasFile(TL.default_session_path, TL.other_file)
+  end)
+end)


### PR DESCRIPTION
Should only impact manually named sessions, making them work more
how I think people would expect them to work.

If you're using a manually named session (either through ':SessionSave
mysession', `:SessionSearch`, or `:SessionRestore mysession`) then we'll
now auto-save to that session on exit instead of always autosaving to
the session derived from the cwd.

Fixes #389 
