### PR TITLE
fix: mark more settings as optional

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -60,17 +60,17 @@ SessionLens                                                        *SessionLens*
 SessionControl                                                  *SessionControl*
 
     Fields: ~
-        {control_dir}       (string)
-        {control_filename}  (string)
+        {control_dir?}       (string)
+        {control_filename?}  (string)
 
 
 SessionLensMappings                                        *SessionLensMappings*
     Session Lens Mapping
 
     Fields: ~
-        {delete_session}     (table)  mode and key for deleting a session from the picker
-        {alternate_session}  (table)  mode and key for swapping to alertnate session from the picker
-        {copy_session}       (table)  mode and key for copying a session from the picker
+        {delete_session?}     (table)  mode and key for deleting a session from the picker
+        {alternate_session?}  (table)  mode and key for swapping to alertnate session from the picker
+        {copy_session?}       (table)  mode and key for copying a session from the picker
 
 
 ==============================================================================

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -50,14 +50,14 @@ local M = {}
 ---@field mappings? SessionLensMappings
 
 ---@class SessionControl
----@field control_dir string
----@field control_filename string
+---@field control_dir? string
+---@field control_filename? string
 
 ---Session Lens Mapping
 ---@class SessionLensMappings
----@field delete_session table mode and key for deleting a session from the picker
----@field alternate_session table mode and key for swapping to alertnate session from the picker
----@field copy_session table mode and key for copying a session from the picker
+---@field delete_session? table mode and key for deleting a session from the picker
+---@field alternate_session? table mode and key for swapping to alertnate session from the picker
+---@field copy_session? table mode and key for copying a session from the picker
 
 ---@type AutoSession.Config
 local defaults = {


### PR DESCRIPTION
So it won't generate warnings if you only set some of them