### PR TITLE
Fix: #208 stop LSs when restoring session

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ Here are the default settings:
   auto_restore_last_session = false, -- On startup, loads the last saved session if session for cwd does not exist
   use_git_branch = false, -- Include git branch name in session name
   lazy_support = true, -- Automatically detect if Lazy.nvim is being used and wait until Lazy is done to make sure session is restored correctly. Does nothing if Lazy isn't being used. Can be disabled if a problem is suspected or for debugging
-  bypass_save_filetypes = nil, -- List of file types to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
+  bypass_save_filetypes = nil, -- List of filetypes to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
   close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session
   args_allow_single_directory = true, -- Follow normal sesion save/load logic if launched with a single directory as the only argument
   args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not load any existing session first. While you can just set this to true, you probably want to set it to a function that decides when to save a session when launched with file args. See documentation for more detail
   continue_restore_on_error = true, -- Keep loading the session even if there's an error
   show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
+  lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   session_lens = {

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -30,6 +30,7 @@ AutoSession.Config                                          *AutoSession.Config*
         {show_auto_restore_notif?}      (boolean)           Whether to show a notification when auto-restoring
         {log_level?}                    (string|integer)    "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
         {cwd_change_handling?}          (boolean)           Follow cwd changes, saving a session before change and restoring after
+        {lsp_stop_on_restore?}          (boolean|function)  Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
         {session_lens?}                 (SessionLens)       Session lens configuration options
         {pre_save_cmds?}                (table)             executes before a session is saved
 
@@ -124,11 +125,12 @@ AutoSession.AutoSaveSession()                      *AutoSession.AutoSaveSession*
 
 
                                                 *AutoSession.AutoRestoreSession*
-AutoSession.AutoRestoreSession({session_name?})
+AutoSession.AutoRestoreSession({session_name?}, {is_startup?})
     Function called by AutoSession when automatically restoring a session.
 
     Parameters: ~
-        {session_name?}  (string)  An optional session to load
+        {session_name?}  (string)       An optional session to load
+        {is_startup?}    (boolean|nil)  Is this autorestore happening on startup
 
     Returns: ~
         (boolean)  returns whether restoring the session was successful or not.
@@ -161,34 +163,41 @@ AutoSession.SaveSessionToDir({session_dir}, {session_name?}, {show_message?})
         (boolean)
 
 
+RestoreOpts                                                        *RestoreOpts*
+
+    Fields: ~
+        {show_message}            (boolean|nil)  Should messages be shown
+        {is_startup_autorestore}  (boolean|nil)  True if this is the the startup autorestore
+
+
                                                     *AutoSession.RestoreSession*
-AutoSession.RestoreSession({session_name?}, {show_message?})
+AutoSession.RestoreSession({session_name?}, {opts?})
     Restores a session from the passed in directory. If no optional session name
     is passed in, it uses the cwd as the session name
 
     Parameters: ~
-        {session_name?}  (string|nil)  Optional session name
-        {show_message?}  (boolean)     Optional, whether to show a message on restore (true by default)
+        {session_name?}  (string|nil)       Optional session name
+        {opts?}          (RestoreOpts|nil)  restore options
 
 
                                              *AutoSession.RestoreSessionFromDir*
-AutoSession.RestoreSessionFromDir({session_dir}, {session_name?}, {show_message?})
+AutoSession.RestoreSessionFromDir({session_dir}, {session_name?}, {opts?})
     Restores a session from the passed in directory. If no optional session name
     is passed in, it uses the cwd as the session name
 
     Parameters: ~
-        {session_dir}    (string)      Directory to write the session file to
-        {session_name?}  (string|nil)  Optional session name
-        {show_message?}  (boolean)     Optional, whether to show a message on restore (true by default)
+        {session_dir}    (string)           Directory to write the session file to
+        {session_name?}  (string|nil)       Optional session name
+        {opts?}          (RestoreOpts|nil)  restore options
 
 
                                                 *AutoSession.RestoreSessionFile*
-AutoSession.RestoreSessionFile({session_path}, {show_message?})
+AutoSession.RestoreSessionFile({session_path}, {opts?})
     Restores a session from a specific file
 
     Parameters: ~
-        {session_path}   (string)   The session file to load
-        {show_message?}  (boolean)  Optional, whether to show a message on restore (true by default)
+        {session_path}  (string)           The session file to load
+        {opts?}         (RestoreOpts|nil)  restore options
 
     Returns: ~
         (boolean)  a session restored

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -26,6 +26,7 @@ local M = {}
 ---@field show_auto_restore_notif? boolean Whether to show a notification when auto-restoring
 ---@field log_level? string|integer "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
 ---@field cwd_change_handling? boolean Follow cwd changes, saving a session before change and restoring after
+---@field lsp_stop_on_restore? boolean|function Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
 ---@field session_lens? SessionLens Session lens configuration options
 ---
 ---Hooks
@@ -79,6 +80,7 @@ local defaults = {
   continue_restore_on_error = true, -- Keep loading the session even if there's an error
   show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
+  lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   ---@type SessionLens

--- a/tests/ls_stop_on_restore_spec.lua
+++ b/tests/ls_stop_on_restore_spec.lua
@@ -1,0 +1,35 @@
+local TL = require "tests/test_lib"
+
+describe("lsp_stop_on_restore", function()
+  local as = require "auto-session"
+  as.setup {}
+  TL.clearSessionFilesAndBuffers()
+  vim.cmd("e " .. TL.test_file)
+  as.SaveSession()
+
+  it("calls user function on restore", function()
+    local stop_called = false
+    as.setup {
+      lsp_stop_on_restore = function()
+        stop_called = true
+      end,
+    }
+
+    as.RestoreSession()
+
+    assert.True(stop_called)
+  end)
+
+  it("doesn't try to stop ls on initial autorestore", function()
+    local stop_called = false
+    as.setup {
+      lsp_stop_on_restore = function()
+        stop_called = true
+      end,
+    }
+
+    as.auto_restore_session_at_vim_enter()
+
+    assert.False(stop_called)
+  end)
+end)

--- a/tests/test_lib.lua
+++ b/tests/test_lib.lua
@@ -1,3 +1,4 @@
+require "plenary"
 local asLib = require "auto-session.lib"
 local M = {}
 


### PR DESCRIPTION
But don't do this on startup as calling vim.lsp.get_clients() causes a
small but noticeable delay on startup.