### PR TITLE
feat: support for custom Snacks picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ AutoSession exposes the following commands that can be used or mapped to any key
 
 :SessionPurgeOrphaned " removes all orphaned sessions with no working directory left.
 
-:SessionSearch " open a session picker, uses Telescope if installed, vim.ui.select otherwise
+:SessionSearch " open a session picker, uses Telescope or Snacks if installed, vim.ui.select otherwise
 
 :Autosession search " open a vim.ui.select picker to choose a session to load.
 :Autosession delete " open a vim.ui.select picker to choose a session to delete.
@@ -153,7 +153,7 @@ If you create a manually named session via `SessionSave my_session` or you resto
 
 ## 🔭 Session Lens
 
-You can use Telescope to see, load, and delete your sessions. It's enabled by default if you have Telescope, but here's the Lazy config that shows the configuration options:
+You can use Telescope or [snacks.nvim](https://github.com/folke/snacks.nvim) to see, load, and delete your sessions. It's enabled by default if you have Telescope, but here's the Lazy config that shows the configuration options:
 
 ```lua
 
@@ -198,7 +198,7 @@ You can use Telescope to see, load, and delete your sessions. It's enabled by de
 ```
 
 You can use `:SessionSearch` to launch the session picker. If `load_on_setup = false`, `:SessionSearch` will initialize the Telescope extension when called. You can also use
-`:Telescope session-lens` to launch the session picker but only if `load_on_setup = true` or you've previously called `SessionSearch`.
+`:Telescope session-lens` to launch the session picker but only if `load_on_setup = true` or you've previously called `SessionSearch`. If you don't have Telescope installed but do have Snacks installed (and the picker enabled), AutoSession will use Snacks as the session picker. No change in configuration is needed (e.g. it will use the same keymap config).
 
 The following default keymaps are available when the session-lens picker is open:
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -95,7 +95,7 @@ This plugin provides the following commands:
 
   `:SessionPurgeOrphaned` - removes all orphaned sessions with no working directory left.
 
-  `:SessionSearch` - open a session picker, uses Telescope if installed, vim.ui.select otherwise
+  `:SessionSearch` - open a session picker, uses Telescope or Snacks if installed, vim.ui.select otherwise
 
 ==============================================================================
 API                                                           *auto-session.api*

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -681,4 +681,38 @@ function Lib.get_session_list(sessions_dir)
   end, entries)
 end
 
+---Get the name of the altnernate session stored in the session control file
+---@return string|nil name of the alternate session, suitable for calls to LoadSession
+function Lib.get_alternate_session_name(session_control_conf)
+  if not session_control_conf then
+    Lib.logger.error "No session_control in config!"
+    return nil
+  end
+
+  local filepath = vim.fn.expand(session_control_conf.control_dir) .. session_control_conf.control_filename
+
+  if vim.fn.filereadable(filepath) == 0 then
+    return nil
+  end
+
+  local json = Lib.load_session_control_file(filepath)
+
+  local sessions = {
+    current = json.current,
+    alternate = json.alternate,
+  }
+
+  Lib.logger.debug("get_alternate_session_name", { sessions = sessions, json = json })
+
+  if sessions.current == sessions.alternate then
+    Lib.logger.info "Current session is the same as alternate, returning nil"
+    return nil
+  end
+  local file_name = vim.fn.fnamemodify(sessions.alternate, ":t")
+  if Lib.is_legacy_file_name(file_name) then
+    return (Lib.legacy_unescape_session_name(file_name):gsub("%.vim$", ""))
+  end
+  return Lib.escaped_session_name_to_session_name(file_name)
+end
+
 return Lib


### PR DESCRIPTION
The main benefit (vs support via vim.ui.select) is keymaps (delete,
alternate, copy). It automatically detects if Snacks is installed (and
the picker enabled) and it uses the same config so no custom config is
required.