### PR TITLE
Root directory not respected as suppressed_dir

### DIFF
--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -520,7 +520,7 @@ function Lib.find_matching_directory(dirToFind, dirs)
     ---@diagnostic disable-next-line: param-type-mismatch
     for path in string.gmatch(dir, "[^\r\n]+") do
       local simplified_path = vim.fn.simplify(path)
-      local path_without_trailing_slashes = string.gsub(simplified_path, "/+$", "")
+      local path_without_trailing_slashes = string.gsub(simplified_path, "([/~].*)/+$", "%1")
 
       -- Lib.logger.debug("find_matching_directory simplified: " .. simplified_path)
 


### PR DESCRIPTION
**Describe the bug**
Whilst I have '/' in my suppressed_dirs config property, a session is created for this directory in certain situations.

**To Reproduce**
1. `cd /`
2. `nvim`
3. Open another previously stored session.
4. Close vim with `:qa`.
5. Reopen vim and list the stored sessions — a session for '/' is created.


**Expected behavior**
I expect no session for '/'.

**Remarks**
I narrowed it down to `Lib.find_matching_directory` using a too naive `gsub` pattern. This pull request contains an updated pattern that in my opinion works better, and leaves the single '/' intact.