### PR TITLE
fix: Session handling for nvim /

### DIFF
--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -97,6 +97,7 @@ end
 ---Removes the trailing separator (if any) from a directory, for both unix and windows
 ---This is needed in some places to avoid duplicate separators that complicate
 ---the path and make equality checks fail (e.g. session control alternate)
+-- Will return '/' if that's the only part of the path
 ---@param dir string The directory path to make sure doesn't have a trailing separator
 ---@return string Dir guaranteed to not have a trailing separator
 function Lib.remove_trailing_separator(dir)
@@ -105,7 +106,7 @@ function Lib.remove_trailing_separator(dir)
     dir = dir:gsub("\\$", "")
   end
 
-  return (dir:gsub("/$", ""))
+  return (dir:gsub("(.)/$", "%1"))
 end
 
 ---Legacy decoding function for windows. Replaces ++ with : and - with \

--- a/tests/lib_spec.lua
+++ b/tests/lib_spec.lua
@@ -24,6 +24,7 @@ describe("Lib / Helper functions", function()
   it("remove_trailing_separator works", function()
     assert.equals("/tmp/blah", Lib.remove_trailing_separator "/tmp/blah/")
     assert.equals("/tmp/blah", Lib.remove_trailing_separator "/tmp/blah")
+    assert.equals("/", Lib.remove_trailing_separator "/")
 
     if vim.fn.has "win32" == 1 then
       assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator "c:\\temp\\blah\\")


### PR DESCRIPTION
When launching as `nvim /`, session_name was getting set to "" because / was getting removed as a trailing separator. If the path is entirely "/", don't remove /. This lets session loading (and suppressing) work as expected.

Fixes #411 