### PR TITLE
fix: Fix session relying on `getcwd` without specifying global (-1)

### DIFF
--- a/lua/auto-session/autocmds.lua
+++ b/lua/auto-session/autocmds.lua
@@ -79,9 +79,9 @@ local function purge_orphaned_sessions()
   local session_files = Lib.get_session_list(M.AutoSession.get_root_dir())
   for _, session in ipairs(session_files) do
     if
-      not Lib.is_named_session(session.session_name)
-      -- don't want any annotations (e.g. git branch)
-      and vim.fn.isdirectory(session.display_name_component) == Lib._VIM_FALSE
+        not Lib.is_named_session(session.session_name)
+        -- don't want any annotations (e.g. git branch)
+        and vim.fn.isdirectory(session.display_name_component) == Lib._VIM_FALSE
     then
       Lib.logger.debug("purge: " .. session.session_name)
       table.insert(orphaned_sessions, session.session_name)
@@ -205,7 +205,7 @@ local function setup_dirchanged_autocmds(AutoSession)
     callback = function()
       Lib.logger.debug "DirChangedPre"
       Lib.logger.debug {
-        cwd = vim.fn.getcwd(),
+        cwd = vim.fn.getcwd(-1, -1),
         target = vim.v.event.directory,
         ["changed window"] = tostring(vim.v.event.changed_window),
         scope = vim.v.event.scope,
@@ -239,7 +239,7 @@ local function setup_dirchanged_autocmds(AutoSession)
   vim.api.nvim_create_autocmd("DirChanged", {
     callback = function()
       Lib.logger.debug "DirChanged"
-      Lib.logger.debug("  cwd: " .. vim.fn.getcwd())
+      Lib.logger.debug("  cwd: " .. vim.fn.getcwd(-1, -1))
       Lib.logger.debug("  changed window: " .. tostring(vim.v.event.changed_window))
       Lib.logger.debug("  scope: " .. vim.v.event.scope)
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -173,7 +173,7 @@ local function suppress_session(session_dir)
 
   -- If session_dir is set, use that otherwise use cwd
   -- session_dir will be set when loading a session from a directory at lauch (i.e. from argv)
-  local cwd = session_dir or vim.fn.getcwd()
+  local cwd = session_dir or vim.fn.getcwd(-1)
 
   if Lib.find_matching_directory(cwd, dirs) then
     Lib.logger.debug "suppress_session found a match, suppressing"
@@ -190,7 +190,7 @@ local function is_allowed_dir()
   end
 
   local dirs = Config.allowed_dirs or {}
-  local cwd = vim.fn.getcwd()
+  local cwd = vim.fn.getcwd(-1)
 
   if Lib.find_matching_directory(cwd, dirs) then
     Lib.logger.debug "is_allowed_dir found a match, allowing"
@@ -209,7 +209,7 @@ end
 ---@return string Returns the escaped version of the name with .vim appended.
 local function get_session_file_name(session_name, legacy)
   if not session_name or session_name == "" then
-    session_name = vim.fn.getcwd()
+    session_name = vim.fn.getcwd(-1)
     Lib.logger.debug("get_session_file_name no session_name, using cwd: " .. session_name)
 
     local git_branch_name = get_git_branch_name()
@@ -279,13 +279,13 @@ end
 ---unless a session for the current working directory exists.
 ---@return boolean True if a session exists for the cwd
 function AutoSession.session_exists_for_cwd()
-  local session_file = get_session_file_name(vim.fn.getcwd())
+  local session_file = get_session_file_name(vim.fn.getcwd(-1))
   if vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0 then
     return true
   end
 
   -- Check legacy sessions
-  session_file = get_session_file_name(vim.fn.getcwd(), true)
+  session_file = get_session_file_name(vim.fn.getcwd(-1), true)
   return vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0
 end
 
@@ -482,7 +482,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
 
     -- We failed to load a session for the other directory. Unless session name matches cwd, we don't
     -- want to enable autosaving since it might replace the session for the cwd
-    if vim.fn.getcwd() ~= session_name then
+    if vim.fn.getcwd(-1) ~= session_name then
       Lib.logger.debug "Not enabling autosave because launch argument didn't load session and doesn't match cwd"
       Config.auto_save = false
     end

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -173,7 +173,7 @@ local function suppress_session(session_dir)
 
   -- If session_dir is set, use that otherwise use cwd
   -- session_dir will be set when loading a session from a directory at lauch (i.e. from argv)
-  local cwd = session_dir or vim.fn.getcwd(-1)
+  local cwd = session_dir or vim.fn.getcwd(-1, -1)
 
   if Lib.find_matching_directory(cwd, dirs) then
     Lib.logger.debug "suppress_session found a match, suppressing"
@@ -190,7 +190,7 @@ local function is_allowed_dir()
   end
 
   local dirs = Config.allowed_dirs or {}
-  local cwd = vim.fn.getcwd(-1)
+  local cwd = vim.fn.getcwd(-1, -1)
 
   if Lib.find_matching_directory(cwd, dirs) then
     Lib.logger.debug "is_allowed_dir found a match, allowing"
@@ -209,7 +209,7 @@ end
 ---@return string Returns the escaped version of the name with .vim appended.
 local function get_session_file_name(session_name, legacy)
   if not session_name or session_name == "" then
-    session_name = vim.fn.getcwd(-1)
+    session_name = vim.fn.getcwd(-1, -1)
     Lib.logger.debug("get_session_file_name no session_name, using cwd: " .. session_name)
 
     local git_branch_name = get_git_branch_name()
@@ -279,13 +279,13 @@ end
 ---unless a session for the current working directory exists.
 ---@return boolean True if a session exists for the cwd
 function AutoSession.session_exists_for_cwd()
-  local session_file = get_session_file_name(vim.fn.getcwd(-1))
+  local session_file = get_session_file_name(vim.fn.getcwd(-1, -1))
   if vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0 then
     return true
   end
 
   -- Check legacy sessions
-  session_file = get_session_file_name(vim.fn.getcwd(-1), true)
+  session_file = get_session_file_name(vim.fn.getcwd(-1, -1), true)
   return vim.fn.filereadable(AutoSession.get_root_dir() .. session_file) ~= 0
 end
 
@@ -482,7 +482,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
 
     -- We failed to load a session for the other directory. Unless session name matches cwd, we don't
     -- want to enable autosaving since it might replace the session for the cwd
-    if vim.fn.getcwd(-1) ~= session_name then
+    if vim.fn.getcwd(-1, -1) ~= session_name then
       Lib.logger.debug "Not enabling autosave because launch argument didn't load session and doesn't match cwd"
       Config.auto_save = false
     end

--- a/tests/get_cwd_spec.lua
+++ b/tests/get_cwd_spec.lua
@@ -1,0 +1,40 @@
+---@diagnostic disable: undefined-field
+local TL = require "tests/test_lib"
+
+describe("cwd lookup", function()
+  local as = require "auto-session"
+
+  require("auto-session").setup {}
+
+  TL.clearSessionFilesAndBuffers()
+
+  it("works when tcd is used", function()
+    assert.equals(0, vim.fn.filereadable(TL.default_session_path))
+    vim.cmd("e " .. TL.test_file)
+    vim.cmd "tabnew"
+    vim.cmd "tcd tests"
+
+    as.SaveSession()
+
+    vim.cmd "tabclose"
+
+    -- Make sure the session was still created for the global directory
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+  end)
+
+  TL.clearSessionFilesAndBuffers()
+
+  it("works when lcd is used", function()
+    assert.equals(0, vim.fn.filereadable(TL.default_session_path))
+    vim.cmd("e " .. TL.test_file)
+    vim.cmd "tabnew"
+    vim.cmd "lcd tests"
+
+    as.SaveSession()
+
+    vim.cmd "tabclose"
+
+    -- Make sure the session was still created for the global directory
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+  end)
+end)


### PR DESCRIPTION
Fixes #45