### PR TITLE
feat: add customizable restore error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Here are the default settings:
   show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
+  restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   session_lens = {

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -31,16 +31,26 @@ AutoSession.Config                                          *AutoSession.Config*
         {log_level?}                    (string|integer)    "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
         {cwd_change_handling?}          (boolean)           Follow cwd changes, saving a session before change and restoring after
         {lsp_stop_on_restore?}          (boolean|function)  Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
+        {restore_error_handler?}        (restore_error_fn)  Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
 
+        {session_lens?}                 (SessionLens)       Session lens configuration options
 
-restore_error_fn                                              *restore_error_fn*
+        {pre_save_cmds?}                (table)             executes before a session is saved
 
-
-    Type: ~
-        fun(error_msg:string):disable_auto_save
+                                                            Hooks
+        {save_extra_cmds?}              (table)             executes before a session is saved
+        {post_save_cmds?}               (table)             executes after a session is saved
+        {pre_restore_cmds?}             (table)             executes before a session is restored
+        {post_restore_cmds?}            (table)             executes after a session is restored
+        {pre_delete_cmds?}              (table)             executes before a session is deleted
+        {post_delete_cmds?}             (table)             executes after a session is deleted
+        {no_restore_cmds?}              (table)             executes at VimEnter when no session is restored
+        {pre_cwd_changed_cmds?}         (table)             executes before cwd is changed if cwd_change_handling is true
+        {post_cwd_changed_cmds?}        (table)             executes after cwd is changed if cwd_change_handling is true
 
 
 SessionLens                                                        *SessionLens*
+
     Sessien Lens Cenfig
 
     Fields: ~
@@ -55,18 +65,27 @@ SessionLens                                                        *SessionLens*
 
 SessionControl                                                  *SessionControl*
 
+
     Fields: ~
         {control_dir?}       (string)
         {control_filename?}  (string)
 
 
 SessionLensMappings                                        *SessionLensMappings*
+
     Session Lens Mapping
 
     Fields: ~
         {delete_session?}     (table)  mode and key for deleting a session from the picker
         {alternate_session?}  (table)  mode and key for swapping to alertnate session from the picker
         {copy_session?}       (table)  mode and key for copying a session from the picker
+
+
+restore_error_fn                                              *restore_error_fn*
+
+
+    Type: ~
+        fun(error_msg:string):disable_auto_save
 
 
 ==============================================================================

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -31,19 +31,13 @@ AutoSession.Config                                          *AutoSession.Config*
         {log_level?}                    (string|integer)    "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
         {cwd_change_handling?}          (boolean)           Follow cwd changes, saving a session before change and restoring after
         {lsp_stop_on_restore?}          (boolean|function)  Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
-        {session_lens?}                 (SessionLens)       Session lens configuration options
-        {pre_save_cmds?}                (table)             executes before a session is saved
 
-                                                            Hooks
-        {save_extra_cmds?}              (table)             executes before a session is saved
-        {post_save_cmds?}               (table)             executes after a session is saved
-        {pre_restore_cmds?}             (table)             executes before a session is restored
-        {post_restore_cmds?}            (table)             executes after a session is restored
-        {pre_delete_cmds?}              (table)             executes before a session is deleted
-        {post_delete_cmds?}             (table)             executes after a session is deleted
-        {no_restore_cmds?}              (table)             executes at VimEnter when no session is restored
-        {pre_cwd_changed_cmds?}         (table)             executes before cwd is changed if cwd_change_handling is true
-        {post_cwd_changed_cmds?}        (table)             executes after cwd is changed if cwd_change_handling is true
+
+restore_error_fn                                              *restore_error_fn*
+
+
+    Type: ~
+        fun(error_msg:string):disable_auto_save
 
 
 SessionLens                                                        *SessionLens*

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -27,6 +27,10 @@ local M = {}
 ---@field log_level? string|integer "debug", "info", "warn", "error" or vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN, vim.log.levels.ERROR
 ---@field cwd_change_handling? boolean Follow cwd changes, saving a session before change and restoring after
 ---@field lsp_stop_on_restore? boolean|function Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
+---
+---@alias restore_error_fn fun(error_msg:string): disable_auto_save:boolean
+---@field restore_error_handler? restore_error_fn Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
+---
 ---@field session_lens? SessionLens Session lens configuration options
 ---
 ---Hooks
@@ -81,6 +85,7 @@ local defaults = {
   show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
+  restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   ---@type SessionLens

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -28,7 +28,6 @@ local M = {}
 ---@field cwd_change_handling? boolean Follow cwd changes, saving a session before change and restoring after
 ---@field lsp_stop_on_restore? boolean|function Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
 ---
----@alias restore_error_fn fun(error_msg:string): disable_auto_save:boolean
 ---@field restore_error_handler? restore_error_fn Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
 ---
 ---@field session_lens? SessionLens Session lens configuration options
@@ -44,7 +43,7 @@ local M = {}
 ---@field no_restore_cmds? table executes at VimEnter when no session is restored
 ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
 ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
-
+---
 ---Sessien Lens Cenfig
 ---@class SessionLens
 ---@field load_on_setup? boolean
@@ -54,16 +53,18 @@ local M = {}
 ---@field previewer? boolean Whether to show a preview of the session file (not very useful to most people)
 ---@field session_control? SessionControl
 ---@field mappings? SessionLensMappings
-
+---
 ---@class SessionControl
 ---@field control_dir? string
 ---@field control_filename? string
-
+---
 ---Session Lens Mapping
 ---@class SessionLensMappings
 ---@field delete_session? table mode and key for deleting a session from the picker
 ---@field alternate_session? table mode and key for swapping to alertnate session from the picker
 ---@field copy_session? table mode and key for copying a session from the picker
+---
+---@alias restore_error_fn fun(error_msg:string): disable_auto_save:boolean
 
 ---@type AutoSession.Config
 local defaults = {


### PR DESCRIPTION
The default error handler ignores "E490: No fold found" errors. For all
other errors, the default handler will show an error message and return
false, which will disable auto-saving.

Users can override that behavior by setting Config.restore_error_handler
to a function that takes a string and returns false if auto-saving
should be disabled.

Fixes #409