### PR TITLE
feat: support for purging old sessions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ["v0.7.2", "v0.8.3", "v0.9.5", "v0.10.3", "nightly"]
+        neovim_version: ["v0.7.2", "v0.9.5", "v0.10.3", "v0.11.0", nightly"]
         include:
           - os: windows-latest
-            neovim_version: v0.10.3
+            neovim_version: v0.11.0
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ["v0.7.2", "v0.9.5", "v0.10.3", "v0.11.0", nightly"]
+        neovim_version: ["v0.7.2", "v0.9.5", "v0.10.3", "v0.11.0", "nightly"]
         include:
           - os: windows-latest
             neovim_version: v0.11.0

--- a/README.md
+++ b/README.md
@@ -501,5 +501,5 @@ Neovim > 0.7
 Tested with:
 
 ```
-NVIM v0.7.2 - NVIM 0.10.1
+NVIM v0.7.2 - NVIM 0.11.0
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Here are the default settings:
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
-  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging)
+  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   session_lens = {

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Here are the default settings:
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
+  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging)
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   session_lens = {

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Here are the default settings:
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
-  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
+  purge_after_minutes = nil, -- Sessions older than purge_after_minutes will be deleted asynchronously on startup, e.g. set to 14400 to delete sessions that haven't been accessed for more than 10 days, defaults to off (no purging), requires >= nvim 0.10
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   session_lens = {

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -33,6 +33,7 @@ AutoSession.Config                                          *AutoSession.Config*
         {lsp_stop_on_restore?}          (boolean|function)  Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
         {restore_error_handler?}        (restore_error_fn)  Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
 
+        {purge_after_days?}             (number|nil)        Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
         {session_lens?}                 (SessionLens)       Session lens configuration options
 
         {pre_save_cmds?}                (table)             executes before a session is saved

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -33,7 +33,7 @@ AutoSession.Config                                          *AutoSession.Config*
         {lsp_stop_on_restore?}          (boolean|function)  Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
         {restore_error_handler?}        (restore_error_fn)  Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
 
-        {purge_after_days?}             (number|nil)        Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
+        {purge_after_minutes?}          (number|nil)        -- Sessions older than purge_after_minutes will be deleted asynchronously on startup, e.g. set to 14400 to delete sessions that haven't been accessed for more than 10 days, defaults to off (no purging), requires >= nvim 0.10
         {session_lens?}                 (SessionLens)       Session lens configuration options
 
         {pre_save_cmds?}                (table)             executes before a session is saved

--- a/lua/auto-session/autocmds.lua
+++ b/lua/auto-session/autocmds.lua
@@ -389,7 +389,7 @@ function M.setup_autocmds(AutoSession)
 
       if not Config.lazy_support then
         -- If auto_restore_lazy_delay_enabled is false, just restore the session as normal
-        AutoSession.auto_restore_session_at_vim_enter()
+        AutoSession.start()
         return
       end
 
@@ -397,14 +397,14 @@ function M.setup_autocmds(AutoSession)
       local ok, lazy_view = pcall(require, "lazy.view")
       if not ok then
         -- No Lazy, load as usual
-        AutoSession.auto_restore_session_at_vim_enter()
+        AutoSession.start()
         return
       end
 
       if not lazy_view.visible() then
         -- Lazy isn't visible, load as usual
         Lib.logger.debug "Lazy is loaded, but not visible, will try to restore session"
-        AutoSession.auto_restore_session_at_vim_enter()
+        AutoSession.start()
         return
       end
 
@@ -449,7 +449,7 @@ function M.setup_autocmds(AutoSession)
         -- Schedule restoration for the next pass in the event loop to time for the window to close
         -- Not doing this could create a blank buffer in the restored session
         vim.schedule(function()
-          AutoSession.auto_restore_session_at_vim_enter()
+          AutoSession.start()
         end)
       end,
     })

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -29,6 +29,7 @@ local M = {}
 ---@field lsp_stop_on_restore? boolean|function Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
 ---
 ---@field restore_error_handler? restore_error_fn Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
+---@field purge_after_days? number|nil Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging)
 ---
 ---@field session_lens? SessionLens Session lens configuration options
 ---
@@ -87,6 +88,7 @@ local defaults = {
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
+  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging)
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   ---@type SessionLens

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -29,7 +29,7 @@ local M = {}
 ---@field lsp_stop_on_restore? boolean|function Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
 ---
 ---@field restore_error_handler? restore_error_fn Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
----@field purge_after_days? number|nil Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging)
+---@field purge_after_days? number|nil Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
 ---
 ---@field session_lens? SessionLens Session lens configuration options
 ---
@@ -88,7 +88,7 @@ local defaults = {
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
-  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging)
+  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   ---@type SessionLens
@@ -236,6 +236,10 @@ end
 function M.check(logger)
   if not vim.tbl_contains(vim.split(vim.o.sessionoptions, ","), "localoptions") then
     logger.warn "vim.o.sessionoptions is missing localoptions. \nUse `:checkhealth autosession` for more info."
+  end
+
+  if M.purge_after_days and vim.fn.has "nvim-0.10" ~= 1 then
+    logger.warn "the purge_after_days options requires nvim >= 0.10"
   end
 
   -- TODO: At some point, we should pop up a warning about old config if

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -29,7 +29,7 @@ local M = {}
 ---@field lsp_stop_on_restore? boolean|function Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
 ---
 ---@field restore_error_handler? restore_error_fn Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
----@field purge_after_days? number|nil Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
+---@field purge_after_minutes? number|nil -- Sessions older than purge_after_minutes will be deleted asynchronously on startup, e.g. set to 14400 to delete sessions that haven't been accessed for more than 10 days, defaults to off (no purging), requires >= nvim 0.10
 ---
 ---@field session_lens? SessionLens Session lens configuration options
 ---
@@ -88,7 +88,7 @@ local defaults = {
   cwd_change_handling = false, -- Follow cwd changes, saving a session before change and restoring after
   lsp_stop_on_restore = false, -- Should language servers be stopped when restoring a session. Can also be a function that will be called if set. Not called on autorestore from startup
   restore_error_handler = nil, -- Called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
-  purge_after_days = nil, -- Sessions older than purge_after_days will be deleted asynchronously on startup, defaults to off (no purging), requires >= nvim 0.10
+  purge_after_minutes = nil, -- Sessions older than purge_after_minutes will be deleted asynchronously on startup, e.g. set to 14400 to delete sessions that haven't been accessed for more than 10 days, defaults to off (no purging), requires >= nvim 0.10
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
 
   ---@type SessionLens
@@ -238,8 +238,8 @@ function M.check(logger)
     logger.warn "vim.o.sessionoptions is missing localoptions. \nUse `:checkhealth autosession` for more info."
   end
 
-  if M.purge_after_days and vim.fn.has "nvim-0.10" ~= 1 then
-    logger.warn "the purge_after_days options requires nvim >= 0.10"
+  if M.purge_after_minutes and vim.fn.has "nvim-0.10" ~= 1 then
+    logger.warn "the purge_after_minutes options requires nvim >= 0.10"
   end
 
   -- TODO: At some point, we should pop up a warning about old config if

--- a/lua/auto-session/health.lua
+++ b/lua/auto-session/health.lua
@@ -73,10 +73,17 @@ local function check_lazy_settings()
   end
 end
 
+function check_features()
+  if Config.purge_after_days and vim.fn.has "nvim-0.10" ~= 1 then
+    warn "The purge_after_days config option requires nvim 0.10 or greater to work"
+  end
+end
+
 function M.check()
   start "vim options"
   check_session_options()
   check_lazy_settings()
+  check_features()
 
   start "Config"
   if Config.has_old_config then

--- a/lua/auto-session/health.lua
+++ b/lua/auto-session/health.lua
@@ -74,8 +74,8 @@ local function check_lazy_settings()
 end
 
 function check_features()
-  if Config.purge_after_days and vim.fn.has "nvim-0.10" ~= 1 then
-    warn "The purge_after_days config option requires nvim 0.10 or greater to work"
+  if Config.purge_after_minutes and vim.fn.has "nvim-0.10" ~= 1 then
+    warn "The purge_after_minutes config option requires nvim 0.10 or greater to work"
   end
 end
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -435,13 +435,13 @@ function AutoSession.start()
   if Config.purge_after_days then
     local work = vim.uv.new_work(Lib.purge_old_sessions, function(purged_sessions_json)
       vim.schedule(function()
-        Lib.logger.info(
-          "Deleted old sessions:\n"
-            .. table.concat(
-              vim.tbl_map(Lib.escaped_session_name_to_session_name, vim.json.decode(purged_sessions_json)),
-              "\n"
-            )
-        )
+        local purged_sessions = vim.json.decode(purged_sessions_json)
+        if not vim.tbl_isempty(purged_sessions) then
+          Lib.logger.info(
+            "Deleted old sessions:\n"
+              .. table.concat(vim.tbl_map(Lib.escaped_session_name_to_session_name, purged_sessions), "\n")
+          )
+        end
       end)
     end)
     work:queue(AutoSession.get_root_dir(), Config.purge_after_days)

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -432,7 +432,7 @@ end
 function AutoSession.start()
   local did_auto_restore = AutoSession.auto_restore_session_at_vim_enter()
 
-  if Config.purge_after_days then
+  if Config.purge_after_minutes then
     local work = vim.uv.new_work(Lib.purge_old_sessions, function(purged_sessions_json)
       vim.schedule(function()
         local purged_sessions = vim.json.decode(purged_sessions_json)
@@ -444,7 +444,7 @@ function AutoSession.start()
         end
       end)
     end)
-    work:queue(AutoSession.get_root_dir(), Config.purge_after_days)
+    work:queue(AutoSession.get_root_dir(), Config.purge_after_minutes)
   end
 
   return did_auto_restore

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -426,11 +426,36 @@ function AutoSession.AutoRestoreSession(session_name, is_startup)
 end
 
 ---@private
+---Called at VimEnter to start AutoSession
+---Will call auto_restore_session_at_vim_enter and also purge sessions (if enabled)
+---@return boolean # Was a session restored
+function AutoSession.start()
+  local did_auto_restore = AutoSession.auto_restore_session_at_vim_enter()
+
+  if Config.purge_after_days then
+    local work = vim.uv.new_work(Lib.purge_old_sessions, function(purged_sessions_json)
+      vim.schedule(function()
+        Lib.logger.info(
+          "Deleted old sessions:\n"
+            .. table.concat(
+              vim.tbl_map(Lib.escaped_session_name_to_session_name, vim.json.decode(purged_sessions_json)),
+              "\n"
+            )
+        )
+      end)
+    end)
+    work:queue(AutoSession.get_root_dir(), Config.purge_after_days)
+  end
+
+  return did_auto_restore
+end
+
+---@private
 ---Called at VimEnter (after Lazy is done) to see if we should automatically restore a session
 ---If launched with a single directory parameter and Config.args_allow_single_directory is true, pass
 ---that in as the session_dir. Handles both 'nvim .' and 'nvim some/dir'
 ---Also make sure to call no_restore if no session was restored
----@return boolean Was a session restored
+---@return boolean # Was a session restored
 function AutoSession.auto_restore_session_at_vim_enter()
   -- Save the launch args here as restoring a session will replace vim.fn.argv. We clear
   -- launch_argv in restore session so it's only used for the session launched from the command

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -760,16 +760,15 @@ end
 
 ---Delete sessions that have access times older than purge_days_old old
 ---@param session_dir string The session directory to look for sessions in
----@param purge_days_old number E.g. 3, delete sessions older than 3 days ago
+---@param purge_older_than_minutes number in minutes, e.g. 14400, delete sessions older than 10 days ago
 ---@return string # json encoded string of escaped session filenames removed
-function Lib.purge_old_sessions(session_dir, purge_days_old)
-  local seconds_per_day = 24 * 3600
+function Lib.purge_old_sessions(session_dir, purge_older_than_minutes)
   local epoch = os.time()
-  local garbage_collect_seconds = purge_days_old * seconds_per_day
+  local garbage_collect_seconds = purge_older_than_minutes * 60
   local scan_dir = assert(vim.uv.fs_scandir(session_dir))
   local out = {}
 
-  if purge_days_old == 0 or garbage_collect_seconds == 0 then
+  if purge_older_than_minutes == 0 or garbage_collect_seconds == 0 then
     return "[]"
   end
 

--- a/tests/purge_old_sessions_spec.lua
+++ b/tests/purge_old_sessions_spec.lua
@@ -2,14 +2,14 @@
 local TL = require "tests/test_lib"
 local stub = require "luassert.stub"
 
-describe("Setting purge_after_days", function()
+describe("Setting purge_after_minutes", function()
   local as = require "auto-session"
 
   -- old session 10 days ago
   local old_session = 10
 
   as.setup {
-    purge_after_days = 3,
+    purge_after_minutes = 60 * 24 * 3,
   }
 
   TL.clearSessionFilesAndBuffers()

--- a/tests/purge_old_sessions_spec.lua
+++ b/tests/purge_old_sessions_spec.lua
@@ -1,0 +1,64 @@
+---@diagnostic disable: undefined-field
+local TL = require "tests/test_lib"
+local stub = require "luassert.stub"
+
+describe("Setting purge_after_days", function()
+  local as = require "auto-session"
+  local Lib = require "auto-session.lib"
+  local c = require "auto-session.config"
+
+  -- old session 10 days ago
+  local old_session = 10
+
+  as.setup {
+    purge_after_days = 3,
+  }
+
+  TL.clearSessionFilesAndBuffers()
+  vim.cmd("e " .. TL.test_file)
+
+  it("does purge old sessions while leaving recent ones", function()
+    as.SaveSession()
+    as.SaveSession(TL.named_session_name)
+
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+    assert.equals(1, vim.fn.filereadable(TL.named_session_path))
+
+    -- Make the named session file appear to be 10 days old
+    local current_time = os.time()
+    local old_time = current_time - (old_session * 24 * 60 * 60) -- 10 days ago in seconds
+
+    -- set the modified and accessed time
+    vim.uv.fs_utime(TL.named_session_path, old_time, old_time)
+
+    -- Verify the file's modification time is now old
+    local file_time = vim.fn.getftime(TL.named_session_path)
+    assert.is_true(file_time < current_time - (old_session * 24 * 60 * 60) + 60) -- Add 60 seconds tolerance
+
+    -- Hook into decode to capture when function finishes
+    local json_decode = vim.json.decode
+    local purge_finished = false
+    stub(vim.json, "decode", function(str)
+      -- session control also uses json functions so we're only looking for json returned by
+      -- Lib.purge_old_sessions
+      if str == '["' .. TL.named_session_name .. '.vim"]' then
+        purge_finished = true
+      end
+      return json_decode(str)
+    end)
+
+    -- Now purge old sessions
+    as.start()
+
+    vim.wait(1000, function()
+      return purge_finished
+    end)
+
+    -- Revert the stub
+    vim.json.decode:revert()
+
+    -- The named session should be deleted, but the default session should remain
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+    assert.equals(0, vim.fn.filereadable(TL.named_session_path))
+  end)
+end)

--- a/tests/purge_old_sessions_spec.lua
+++ b/tests/purge_old_sessions_spec.lua
@@ -4,8 +4,6 @@ local stub = require "luassert.stub"
 
 describe("Setting purge_after_days", function()
   local as = require "auto-session"
-  local Lib = require "auto-session.lib"
-  local c = require "auto-session.config"
 
   -- old session 10 days ago
   local old_session = 10
@@ -17,48 +15,51 @@ describe("Setting purge_after_days", function()
   TL.clearSessionFilesAndBuffers()
   vim.cmd("e " .. TL.test_file)
 
-  it("does purge old sessions while leaving recent ones", function()
-    as.SaveSession()
-    as.SaveSession(TL.named_session_name)
+  -- requires nvim >= 0.10
+  if vim.fn.has "nvim-0.10" == 1 then
+    it("does purge old sessions while leaving recent ones", function()
+      as.SaveSession()
+      as.SaveSession(TL.named_session_name)
 
-    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
-    assert.equals(1, vim.fn.filereadable(TL.named_session_path))
+      assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+      assert.equals(1, vim.fn.filereadable(TL.named_session_path))
 
-    -- Make the named session file appear to be 10 days old
-    local current_time = os.time()
-    local old_time = current_time - (old_session * 24 * 60 * 60) -- 10 days ago in seconds
+      -- Make the named session file appear to be 10 days old
+      local current_time = os.time()
+      local old_time = current_time - (old_session * 24 * 60 * 60) -- 10 days ago in seconds
 
-    -- set the modified and accessed time
-    vim.uv.fs_utime(TL.named_session_path, old_time, old_time)
+      -- set the modified and accessed time
+      vim.uv.fs_utime(TL.named_session_path, old_time, old_time)
 
-    -- Verify the file's modification time is now old
-    local file_time = vim.fn.getftime(TL.named_session_path)
-    assert.is_true(file_time < current_time - (old_session * 24 * 60 * 60) + 60) -- Add 60 seconds tolerance
+      -- Verify the file's modification time is now old
+      local file_time = vim.fn.getftime(TL.named_session_path)
+      assert.is_true(file_time < current_time - (old_session * 24 * 60 * 60) + 60) -- Add 60 seconds tolerance
 
-    -- Hook into decode to capture when function finishes
-    local json_decode = vim.json.decode
-    local purge_finished = false
-    stub(vim.json, "decode", function(str)
-      -- session control also uses json functions so we're only looking for json returned by
-      -- Lib.purge_old_sessions
-      if str == '["' .. TL.named_session_name .. '.vim"]' then
-        purge_finished = true
-      end
-      return json_decode(str)
+      -- Hook into decode to capture when function finishes
+      local json_decode = vim.json.decode
+      local purge_finished = false
+      stub(vim.json, "decode", function(str)
+        -- session control also uses json functions so we're only looking for json returned by
+        -- Lib.purge_old_sessions
+        if str == '["' .. TL.named_session_name .. '.vim"]' then
+          purge_finished = true
+        end
+        return json_decode(str)
+      end)
+
+      -- Now purge old sessions
+      as.start()
+
+      vim.wait(1000, function()
+        return purge_finished
+      end)
+
+      -- Revert the stub
+      vim.json.decode:revert()
+
+      -- The named session should be deleted, but the default session should remain
+      assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+      assert.equals(0, vim.fn.filereadable(TL.named_session_path))
     end)
-
-    -- Now purge old sessions
-    as.start()
-
-    vim.wait(1000, function()
-      return purge_finished
-    end)
-
-    -- Revert the stub
-    vim.json.decode:revert()
-
-    -- The named session should be deleted, but the default session should remain
-    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
-    assert.equals(0, vim.fn.filereadable(TL.named_session_path))
-  end)
+  end
 end)


### PR DESCRIPTION
Had some time so implemented the purging feature, largely with the code from #404 (thanks @holmanb!)

Add config option, purge_after_days which is disabled by default. If set
to a number greater than 0, then sessions older than that will be
deleted automatically.

Fixes #404

Requires nvim >= 0.10 (noted in the documentation and shows a warning on startup/in checkhealth if the `purge_after_days` is set and nvim <= 0.10)