### PR TITLE
refactor(Config)!: Clean up picker customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,7 @@ Here are the default settings:
 
   session_lens = {
     load_on_setup = true, -- Initialize on startup (requires Telescope)
-    theme_conf = { -- Pass through for Telescope theme options
-      -- layout_config = { -- As one example, can change width/height of picker
-      --   width = 0.8,    -- percent of window
-      --   height = 0.5,
-      -- },
-    },
-    previewer = false, -- File preview for session picker
-
+    picker_opts = nil, -- Table passed to Telescope / Snacks to configure the picker. See below for more information
     mappings = {
       -- Mode can be a string or a table, e.g. {"i", "n"} for both insert and normal mode
       delete_session = { "i", "<C-D>" },
@@ -156,9 +149,9 @@ If you create a manually named session via `SessionSave my_session` or you resto
 
 # 📖 More Configuration Details
 
-## 🔭 Session Lens
+## 🔭 Session Picker
 
-You can use Telescope or [snacks.nvim](https://github.com/folke/snacks.nvim) to see, load, and delete your sessions. It's enabled by default if you have Telescope, but here's the Lazy config that shows the configuration options:
+You can use Telescope or [snacks.nvim](https://github.com/folke/snacks.nvim) to see, load, and delete your sessions. The configuration options are in the `session_lens` section:
 
 ```lua
 
@@ -176,40 +169,56 @@ You can use Telescope or [snacks.nvim](https://github.com/folke/snacks.nvim) to 
   ---@module "auto-session"
   ---@type AutoSession.Config
   opts = {
-    -- ⚠️ This will only work if Telescope.nvim is installed
     -- The following are already the default values, no need to provide them if these are already the settings you want.
     session_lens = {
-      -- If load_on_setup is false, make sure you use `:SessionSearch` to open the picker as it will initialize everything first
-      load_on_setup = true,
-      previewer = false,
       mappings = {
         -- Mode can be a string or a table, e.g. {"i", "n"} for both insert and normal mode
         delete_session = { "i", "<C-D>" },
         alternate_session = { "i", "<C-S>" },
         copy_session = { "i", "<C-Y>" },
       },
-      -- Can also set some Telescope picker options
-      -- For all options, see: https://github.com/nvim-telescope/telescope.nvim/blob/master/doc/telescope.txt#L112
-      theme_conf = {
-        border = true,
+
+      picker_opts = {
+        -- For Telescope, you can set theme options here, see:
+        -- https://github.com/nvim-telescope/telescope.nvim/blob/master/doc/telescope.txt#L112
+        -- https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/themes.lua
+        --
+        -- border = true,
         -- layout_config = {
         --   width = 0.8, -- Can set width and height as percent of window
         --   height = 0.5,
         -- },
+
+        -- For Snacks, you can set layout options here, see:
+        -- https://github.com/folke/snacks.nvim/blob/main/docs/picker.md#%EF%B8%8F-layouts
+        --
+        -- preset = "dropdown",
+        -- preview = false,
+        -- layout = {
+        --   width = 0.4,
+        --   height = 0.4,
+        -- },
       },
+
+
+      -- Telescope only: If load_on_setup is false, make sure you use `:SessionSearch` to open the picker as it will initialize everything first
+      load_on_setup = true,
     },
   }
 }
 ```
 
-You can use `:SessionSearch` to launch the session picker. If `load_on_setup = false`, `:SessionSearch` will initialize the Telescope extension when called. You can also use
-`:Telescope session-lens` to launch the session picker but only if `load_on_setup = true` or you've previously called `SessionSearch`. If you don't have Telescope installed but do have Snacks installed (and the picker enabled), AutoSession will use Snacks as the session picker. No change in configuration is needed (e.g. it will use the same keymap config).
+Use `:SessionSearch` to launch the session picker. It will look for Telescope or Snacks and, if it can't find either, fall back to `vim.select`.
+
+If you're using Telescope and want to launch the picker via `:Telescope session-lens`, set `load_on_setup = true` or make sure you've called `:SessionSearch` first.
 
 The following default keymaps are available when the session-lens picker is open:
 
 - `<CR>` loads the currently highlighted session.
 - `<C-S>` swaps to the previously opened session. This can give you a nice flow if you're constantly switching between two projects.
 - `<C-D>` will delete the currently highlighted session. This makes it easy to keep the session list clean.
+
+When using Telescope or Snacks, you can customize the picker using `picker_opts`. Refer to the links above for the specific picker configuration options.
 
 NOTE: If you previously installed `rmagatti/session-lens`, you should remove it from your config as it is no longer necessary.
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -54,14 +54,11 @@ AutoSession.Config                                          *AutoSession.Config*
 
 SessionLens                                                        *SessionLens*
 
-    Sessien Lens Cenfig
+    Session Lens Cenfig
 
     Fields: ~
         {load_on_setup?}    (boolean)
-        {shorten_path?}     (boolean)              Deprecated, pass { 'shorten' } to path_display
-        {path_display?}     (table)                An array that specifies how to handle paths. Read :h telescope.defaults.path_display
-        {theme_conf?}       (table)                Telescope theme options
-        {previewer?}        (boolean)              Whether to show a preview of the session file (not very useful to most people)
+        {picker_opts?}      (table)                Telescope/Snacks picker options
         {session_control?}  (SessionControl)
         {mappings?}         (SessionLensMappings)
 

--- a/lua/auto-session/autocmds.lua
+++ b/lua/auto-session/autocmds.lua
@@ -131,6 +131,13 @@ end
 
 local function snacks_session_search()
   local mappings = Config.session_lens.mappings or {}
+
+  -- If layout is nil or empty, default to select preset
+  local layout = Config.session_lens.picker_opts or {}
+  if vim.tbl_isempty(layout) then
+    layout = { preset = "select" }
+  end
+
   Snacks.picker.pick {
     title = "Sessions",
     finder = function()
@@ -141,9 +148,7 @@ local function snacks_session_search()
       item.text = item.display_name
       item.file = item.path
     end,
-    layout = {
-      preview = Config.session_lens.previewer,
-    },
+    layout = layout,
     win = {
       input = {
         keys = {

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -47,13 +47,10 @@ local M = {}
 ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
 ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
 ---
----Sessien Lens Cenfig
+---Session Lens Cenfig
 ---@class SessionLens
 ---@field load_on_setup? boolean
----@field shorten_path? boolean Deprecated, pass { 'shorten' } to path_display
----@field path_display? table An array that specifies how to handle paths. Read :h telescope.defaults.path_display
----@field theme_conf? table Telescope theme options
----@field previewer? boolean Whether to show a preview of the session file (not very useful to most people)
+---@field picker_opts? table Telescope/Snacks picker options
 ---@field session_control? SessionControl
 ---@field mappings? SessionLensMappings
 ---
@@ -98,13 +95,7 @@ local defaults = {
   ---@type SessionLens
   session_lens = {
     load_on_setup = true, -- Initialize on startup (requires Telescope)
-    theme_conf = { -- Pass through for Telescope theme options
-      -- layout_config = { -- As one example, can change width/height of picker
-      --   width = 0.8,    -- percent of window
-      --   height = 0.5,
-      -- },
-    },
-    previewer = false, -- File preview for session picker
+    picker_opts = nil, -- Table passed to Telescope / Snacks to configure the picker
 
     ---@type SessionLensMappings
     mappings = {
@@ -213,10 +204,32 @@ local function check_old_config_names(config)
     end
   end
 
-  if config.session_lens and config.session_lens.shorten_path ~= nil then
-    M.has_old_config = true
+  -- check session_lens for old config
+  if config.session_lens then
+    -- check for theme_conf first
+    ---@diagnostic disable-next-line: undefined-field
+    if config.session_lens.theme_conf then
+      M.has_old_config = true
+      config.session_lens.picker_opts = config.session_lens.theme_conf
+      config.session_lens.theme_conf = nil
+    end
+
     if config.session_lens.shorten_path then
-      config.session_lens.path_display = { "shorten" }
+      M.has_old_config = true
+      if not config.session_lens.picker_opts then
+        config.session_lens.picker_opts = {}
+      end
+      config.session_lens.picker_opts.path_display = { "shorten" }
+      config.session_lens.shorten_path = nil
+    end
+
+    if config.session_lens.path_display then
+      M.has_old_config = true
+      if not config.session_lens.picker_opts then
+        config.session_lens.picker_opts = {}
+      end
+      config.session_lens.picker_opts.path_display = config.session_lens.path_display
+      config.session_lens.path_display = nil
     end
   end
 end

--- a/lua/auto-session/session-lens/init.lua
+++ b/lua/auto-session/session-lens/init.lua
@@ -22,22 +22,23 @@ SessionLens.search_session = function(custom_opts)
   end
   custom_opts = custom_opts or {}
 
-  -- get the theme defaults, with any overrides in custom_opts.theme_conf
-  local theme_opts = telescope_themes.get_dropdown(custom_opts.theme_conf)
-
-  -- path_display could've been in theme_conf but that's not where we put it
-  if custom_opts.path_display then
-    -- copy over to the theme options
-    theme_opts.path_display = custom_opts.path_display
+  if not custom_opts.picker_opts then
+    -- If there are no picker options, default to previewer off
+    custom_opts.picker_opts = { previewer = false }
+  elseif custom_opts.picker_opts.previewer == nil then
+    -- If there are picker options but previewer wasn't explicitly set on,
+    -- default it to off
+    custom_opts.picker_opts.previewer = false
   end
+
+  -- get the theme defaults, with any overrides in custom_opts.picker_opts
+  local theme_opts = telescope_themes.get_dropdown(custom_opts.picker_opts)
 
   if theme_opts.path_display then
     -- If there's a path_display setting, we have to force path_display.absolute = true here,
     -- otherwise the session for the cwd will be displayed as just a dot
     theme_opts.path_display.absolute = true
   end
-
-  theme_opts.previewer = custom_opts.previewer
 
   local session_root_dir = AutoSession.get_root_dir()
 


### PR DESCRIPTION
Rename `theme_conf` to `picker_opts` to better represent what it does.

Deprecated `shorten_path` (even harder this time) and `path_display`
when under the `session_lens` config block. Both of those are Telescope
specific and should be in `picker_opts`. We'll automatically detect when
they're still in `session_lens` and set them in `picker_opts` and show
the old config warning `checkhealth`.

Added support for configuring the session picker when using Snacks via
`picker_opts`.

Change is only listed as breaking because the `previewer` option was
removed. The default is still that no preview is displayed (for both
Telescope and Snacks) but if you want to turn preview on for the session
picker for some reason, set the appropriate field in `picker_opts`
(`previewer = true,` for Telescope and `preview = true,` for Snacks)