### PR TITLE
feat: Add ignore_filetypes_on_save option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ["v0.7.2", "v0.9.5", "v0.10.3", "v0.11.2", "nightly"]
+        neovim_version: ["v0.10.3", "v0.11.2", "nightly"]
         include:
           - os: windows-latest
             neovim_version: v0.11.2

--- a/README.md
+++ b/README.md
@@ -508,10 +508,10 @@ If that doesn't help, you can:
 
 # Compatibility
 
-Neovim > 0.7
+Neovim > 0.10.3
 
 Tested with:
 
 ```
-NVIM v0.7.2 - NVIM 0.11.2
+NVIM v0.10.3 - NVIM 0.11.2
 ```

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -81,6 +81,7 @@ local defaults = {
   git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
   lazy_support = true, -- Automatically detect if Lazy.nvim is being used and wait until Lazy is done to make sure session is restored correctly. Does nothing if Lazy isn't being used. Can be disabled if a problem is suspected or for debugging
   bypass_save_filetypes = nil, -- List of filetypes to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
+  ignore_filetypes_on_save = nil, -- List of filetypes to close buffers of before saving a session
   close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session
   args_allow_single_directory = true, -- Follow normal session save/load logic if launched with a single directory as the only argument
   args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not load any existing session first. While you can just set this to true, you probably want to set it to a function that decides when to save a session when launched with file args. See documentation for more detail

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -166,7 +166,7 @@ local function close_ignored_filetypes()
       local buf_ft = vim.api.nvim_buf_get_option(buf, "filetype")
       for _, ft_to_ignore in ipairs(filetypes_to_ignore) do
         if buf_ft == ft_to_ignore then
-          vim.cmd("bdelete! " .. buf)
+          vim.api.nvim_buf_delete(buf, { force = true })
           break
         end
       end
@@ -465,7 +465,7 @@ function AutoSession.start()
         if not vim.tbl_isempty(purged_sessions) then
           Lib.logger.info(
             "Deleted old sessions:\n"
-              .. table.concat(vim.tbl_map(Lib.escaped_session_name_to_session_name, purged_sessions), "\n")
+            .. table.concat(vim.tbl_map(Lib.escaped_session_name_to_session_name, purged_sessions), "\n")
           )
         end
       end)
@@ -490,9 +490,9 @@ function AutoSession.auto_restore_session_at_vim_enter()
 
   -- Is there exactly one argument and is it a directory?
   if
-    Config.args_allow_single_directory
-    and #launch_argv == 1
-    and vim.fn.isdirectory(launch_argv[1]) == Lib._VIM_TRUE
+      Config.args_allow_single_directory
+      and #launch_argv == 1
+      and vim.fn.isdirectory(launch_argv[1]) == Lib._VIM_TRUE
   then
     -- Get the full path of the directory and make sure it doesn't have a trailing path_separator
     -- to make sure we find the session
@@ -502,7 +502,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
     if Config.git_use_branch_name then
       -- Get the git branch for that directory, no legacy git name support
       session_name =
-        Lib.combine_session_name_with_git_branch(session_name, Lib.get_git_branch_name(session_name), false)
+          Lib.combine_session_name_with_git_branch(session_name, Lib.get_git_branch_name(session_name), false)
       Lib.logger.debug("git enabled, launch argument with potential git branch: " .. session_name)
     end
 
@@ -529,10 +529,10 @@ function AutoSession.auto_restore_session_at_vim_enter()
       if last_session_name then
         Lib.logger.debug("Found last session: " .. last_session_name)
         if
-          AutoSession.RestoreSession(
-            last_session_name,
-            { show_message = Config.show_auto_restore_notif, is_startup_autorestore = true }
-          )
+            AutoSession.RestoreSession(
+              last_session_name,
+              { show_message = Config.show_auto_restore_notif, is_startup_autorestore = true }
+            )
         then
           return true
         end
@@ -785,8 +785,8 @@ function AutoSession.RestoreSessionFile(session_path, opts)
 
   if not success then
     if
-      (type(Config.restore_error_handler) == "function" and not Config.restore_error_handler(result))
-      or not restore_error_handler(result)
+        (type(Config.restore_error_handler) == "function" and not Config.restore_error_handler(result))
+        or not restore_error_handler(result)
     then
       Lib.logger.debug "Error while restoring, disabling autosave"
       Config.auto_save = false

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -131,7 +131,7 @@ local function bypass_save_by_filetype()
   for _, current_window in ipairs(windows) do
     local buf = vim.api.nvim_win_get_buf(current_window)
 
-      local buf_ft = vim.bo[buf].filetype
+    local buf_ft = vim.bo[buf].filetype
 
     local local_return = false
     for _, ft_to_bypass in ipairs(filetypes_to_bypass) do
@@ -161,7 +161,7 @@ local function close_ignored_filetypes()
 
   for _, buf in ipairs(buffers) do
     if vim.api.nvim_buf_is_loaded(buf) then
-        local buf_ft = vim.bo[buf].filetype
+      local buf_ft = vim.bo[buf].filetype
       for _, ft_to_ignore in ipairs(filetypes_to_ignore) do
         if buf_ft == ft_to_ignore then
           vim.api.nvim_buf_delete(buf, { force = true })
@@ -676,7 +676,7 @@ function AutoSession.RestoreSessionFromDir(session_dir, session_name, opts)
 
     Lib.logger.debug("RestoreSessionFromDir renaming legacy session: " .. legacy_escaped_session_name)
     ---@diagnostic disable-next-line: undefined-field
-      if not vim.uv.fs_rename(legacy_session_path, session_path) then
+    if not vim.uv.fs_rename(legacy_session_path, session_path) then
       Lib.logger.debug(
         "RestoreSessionFromDir rename failed!",
         { session_path = session_path, legacy_session_path = legacy_session_path }
@@ -693,7 +693,7 @@ function AutoSession.RestoreSessionFromDir(session_dir, session_name, opts)
     if vim.fn.filereadable(legacy_user_commands_path) == 1 and not Lib.is_session_file(legacy_user_commands_path) then
       if vim.fn.filereadable(user_commands_path) == 0 then
         Lib.logger.debug("RestoreSessionFromDir Renaming legacy user commands" .. legacy_user_commands_path)
-          vim.uv.fs_rename(legacy_user_commands_path, user_commands_path)
+        vim.uv.fs_rename(legacy_user_commands_path, user_commands_path)
       end
     end
   end

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -131,9 +131,7 @@ local function bypass_save_by_filetype()
   for _, current_window in ipairs(windows) do
     local buf = vim.api.nvim_win_get_buf(current_window)
 
-    -- Deprecated as 0.9.0, should update to following when we only want to support 0.9.0+
-    -- local buf_ft = vim.bo[buf].filetype
-    local buf_ft = vim.api.nvim_buf_get_option(buf, "filetype")
+      local buf_ft = vim.bo[buf].filetype
 
     local local_return = false
     for _, ft_to_bypass in ipairs(filetypes_to_bypass) do
@@ -163,7 +161,7 @@ local function close_ignored_filetypes()
 
   for _, buf in ipairs(buffers) do
     if vim.api.nvim_buf_is_loaded(buf) then
-      local buf_ft = vim.api.nvim_buf_get_option(buf, "filetype")
+        local buf_ft = vim.bo[buf].filetype
       for _, ft_to_ignore in ipairs(filetypes_to_ignore) do
         if buf_ft == ft_to_ignore then
           vim.api.nvim_buf_delete(buf, { force = true })
@@ -678,7 +676,7 @@ function AutoSession.RestoreSessionFromDir(session_dir, session_name, opts)
 
     Lib.logger.debug("RestoreSessionFromDir renaming legacy session: " .. legacy_escaped_session_name)
     ---@diagnostic disable-next-line: undefined-field
-    if not vim.loop.fs_rename(legacy_session_path, session_path) then
+      if not vim.uv.fs_rename(legacy_session_path, session_path) then
       Lib.logger.debug(
         "RestoreSessionFromDir rename failed!",
         { session_path = session_path, legacy_session_path = legacy_session_path }
@@ -695,7 +693,7 @@ function AutoSession.RestoreSessionFromDir(session_dir, session_name, opts)
     if vim.fn.filereadable(legacy_user_commands_path) == 1 and not Lib.is_session_file(legacy_user_commands_path) then
       if vim.fn.filereadable(user_commands_path) == 0 then
         Lib.logger.debug("RestoreSessionFromDir Renaming legacy user commands" .. legacy_user_commands_path)
-        vim.loop.fs_rename(legacy_user_commands_path, user_commands_path)
+          vim.uv.fs_rename(legacy_user_commands_path, user_commands_path)
       end
     end
   end

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -320,8 +320,6 @@ function AutoSession.AutoSaveSession()
     end
   end
 
-  close_ignored_filetypes()
-
   -- Don't try to show a message as we're exiting
   return AutoSession.SaveSession(current_session, false)
 end
@@ -589,6 +587,8 @@ function AutoSession.SaveSessionToDir(session_dir, session_name, show_message)
   end
 
   local session_path = session_dir .. escaped_session_name
+
+  close_ignored_filetypes()
 
   AutoSession.run_cmds "pre_save"
 

--- a/tests/ignore_filetypes_on_save_spec.lua
+++ b/tests/ignore_filetypes_on_save_spec.lua
@@ -1,0 +1,46 @@
+---@diagnostic disable: undefined-field
+local TL = require "tests/test_lib"
+
+describe("Ignore filetypes on save", function()
+  local as = require "auto-session"
+
+  as.setup {
+    ignore_filetypes_on_save = { "text" },
+  }
+
+  TL.clearSessionFilesAndBuffers()
+
+  it("closes buffers of ignored filetypes before saving", function()
+    vim.cmd("e " .. TL.test_file) -- this is a text file
+    vim.cmd "e tests/ignore_filetypes_on_save_spec.lua"
+
+    -- generate default session
+    assert.True(as.AutoSaveSession())
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+
+    -- Check that the text file is not in the session
+    assert.False(TL.sessionHasFile(TL.default_session_path, TL.test_file))
+    -- Check that the lua file is in the session
+    assert.True(TL.sessionHasFile(TL.default_session_path, "tests/ignore_filetypes_on_save_spec.lua"))
+  end)
+
+  TL.clearSessionFilesAndBuffers()
+
+  it("does not close buffers of other filetypes", function()
+    vim.cmd("e " .. TL.test_file) -- this is a text file
+    vim.cmd "e tests/ignore_filetypes_on_save_spec.lua"
+
+    as.setup {
+      ignore_filetypes_on_save = { "lua" },
+    }
+
+    -- generate default session
+    assert.True(as.AutoSaveSession())
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+
+    -- Check that the text file is in the session
+    assert.True(TL.sessionHasFile(TL.default_session_path, TL.test_file))
+    -- Check that the lua file is not in the session
+    assert.False(TL.sessionHasFile(TL.default_session_path, "tests/ignore_filetypes_on_save_spec.lua"))
+  end)
+end)


### PR DESCRIPTION
### feat: Add ignore_filetypes_on_save option

This PR introduces a new option `ignore_filetypes_on_save` that allows users to specify a list of filetypes to be closed before a session is saved. This is useful for preventing buffers of certain filetypes from being saved in a session.

This functionality works for both automatic session saving on exit and manual saving with `:SessionSave`.

Additionally, this PR includes the following changes:
*   Removes support for Neovim versions older than 0.10.3 from the CI workflow to address test failures with deprecated APIs.
*   Updates the `README.md` to reflect the new minimum Neovim version requirement.

Closes #447