### PR TITLE
ignore E16 invalid range when attempting to restore folds

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -686,7 +686,7 @@ end
 ---@return boolean enable_auto_save Return false to disable auto-saving, true to leave it on
 local function restore_error_handler(error_msg)
   -- Ignore fold errors as discussed in https://github.com/rmagatti/auto-session/issues/409
-  if error_msg and string.find(error_msg, "E490: No fold found") then
+  if error_msg and (string.find(error_msg, "E490: No fold found") or string.find(error_msg, "E16: Invalid range")) then
     Lib.logger.debug "Ignoring fold error on restore"
     return true
   end

--- a/tests/restore_error_handler_spec.lua
+++ b/tests/restore_error_handler_spec.lua
@@ -65,4 +65,37 @@ describe("restore_error_handler", function()
     assert.False(as.RestoreSession())
     assert.True(was_called)
   end)
+
+  -- Test for the default error handler ignoring fold errors
+  as.setup()
+
+  it("ignores E16 Invalid range fold errors", function()
+    TL.clearSessionFilesAndBuffers()
+    vim.cmd("e " .. TL.test_file)
+    as.SaveSession()
+
+    -- add an E16 fold error to the session file
+    local uv = vim.loop
+    local fd = assert(uv.fs_open(TL.default_session_path, "a", 438))
+    uv.fs_write(fd, "100,200fold\n", -1)  -- This will cause E16: Invalid range
+    uv.fs_close(fd)
+
+    -- This should succeed (return true) because E16 errors are ignored
+    assert.True(as.RestoreSession())
+  end)
+
+  it("ignores E490 No fold found errors", function()
+    TL.clearSessionFilesAndBuffers()
+    vim.cmd("e " .. TL.test_file)
+    as.SaveSession()
+
+    -- add an E490 fold error to the session file
+    local uv = vim.loop
+    local fd = assert(uv.fs_open(TL.default_session_path, "a", 438))
+    uv.fs_write(fd, "foldopen\n", -1)  -- This will cause E490: No fold found
+    uv.fs_close(fd)
+
+    -- This should succeed (return true) because E490 errors are ignored
+    assert.True(as.RestoreSession())
+  end)
 end)


### PR DESCRIPTION
somewhat related to #409 , extracted out of #456 

This is an error I often run into when restoring sessions, especially when multiple work streams overlap and code moves around