### PR TITLE
fix: nil filtering issue in `Lib.get_session_list`

### DIFF
--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -646,7 +646,7 @@ function Lib.get_session_list(sessions_dir)
 
   local entries = Lib.sorted_readdir(sessions_dir)
 
-  return vim.tbl_map(function(file_name)
+  local result = vim.tbl_map(function(file_name)
     local session_name
     local display_name_component
 
@@ -682,6 +682,13 @@ function Lib.get_session_list(sessions_dir)
       path = sessions_dir .. file_name,
     }
   end, entries)
+  
+  -- Filter out nil entries (files that didn't pass is_session_file check)
+  local filtered_result = vim.tbl_filter(function(entry)
+    return entry ~= nil
+  end, result)
+
+  return filtered_result
 end
 
 ---Get the name of the altnernate session stored in the session control file

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -644,9 +644,9 @@ function Lib.get_session_list(sessions_dir)
     return {}
   end
 
-  local entries = Lib.sorted_readdir(sessions_dir)
+  local files = Lib.sorted_readdir(sessions_dir)
 
-  local result = vim.tbl_map(function(file_name)
+  local session_entries = vim.tbl_map(function(file_name)
     local session_name
     local display_name_component
 
@@ -681,14 +681,14 @@ function Lib.get_session_list(sessions_dir)
       file_name = file_name,
       path = sessions_dir .. file_name,
     }
-  end, entries)
-  
-  -- Filter out nil entries (files that didn't pass is_session_file check)
-  local filtered_result = vim.tbl_filter(function(entry)
-    return entry ~= nil
-  end, result)
+  end, files)
 
-  return filtered_result
+  -- Filter out nil entries (files that didn't pass is_session_file check)
+  local filtered_session_entries = vim.tbl_filter(function(entry)
+    return entry ~= nil
+  end, session_entries)
+
+  return filtered_session_entries
 end
 
 ---Get the name of the altnernate session stored in the session control file


### PR DESCRIPTION
This issue was causing the session lens to break when extra command files are present, since telescope expects to be passed a dense array

Discovered in the process of iterating on #456 