### PR TITLE
chore!: drop support for nvim <=0.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,26 +26,31 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ["v0.7.2", "v0.9.5", "v0.10.3", "v0.11.2", "nightly"]
+        neovim_version: ["v0.10.3", "v0.11.3", "nightly"]
         include:
+          - os: macos-latest
+            neovim_version: v0.11.3
           - os: windows-latest
-            neovim_version: v0.11.2
+            neovim_version: v0.11.3
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
-
-      # For sshing in to debug GH actions
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
-      #   with:
-      #     detached: true
 
       - name: setup neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.neovim_version }}
+
+      - name: Add nvim to PATH
+        run: echo "${{ steps.setup_nvim.outputs.executable }}" >> $GITHUB_PATH
+
+      # # For sshing in to debug GH actions
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      #   with:
+      #     detached: true
 
       - name: Run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,11 @@ TELESCOPE_DIR = .test/telescope
 TELESCOPE_VER = 0.1.8
 
 # FIXME: Using my fork on mini.nvim just for https://github.com/echasnovski/mini.nvim/pull/1101
-MINI_URL = https://github.com/cameronr/mini.nvim
+MINI_URL = https://github.com/echasnovski/mini.nvim
 MINI_DIR = .test/mini.nvim
-MINI_VER = windows
+MINI_VER = v0.16.0
+
+NVIM = nvim
 
 PLUGINS := $(PLENARY_DIR) $(TELESCOPE_DIR) ${MINI_DIR}
 
@@ -25,15 +27,16 @@ test: plenary-tests mini-tests
 # PlenaryBustedFile, on the other hand, starts two processes per spec (one to manage running the spec and then one to actually run the spec)
 # But it's very convenient to be able to run a single spec when test/developing
 plenary-tests: $(PLUGINS)
-	nvim --clean --headless -u scripts/minimal_init.lua +"PlenaryBustedDirectory tests {minimal_init = 'scripts/minimal_init.lua', sequential=true}"
+	# DEBUG_PLENARY=1 $(NVIM) --clean --headless -u scripts/minimal_init.lua +"PlenaryBustedDirectory tests {minimal_init = 'scripts/minimal_init.lua', sequential=true}"
+	$(NVIM) --clean --headless -u scripts/minimal_init.lua +"PlenaryBustedDirectory tests {minimal_init = 'scripts/minimal_init.lua', sequential=true}"
 
 # Rule that lets you run an individual spec. Currently requires my Plenary fork above
 $(FILES): $(PLUGINS)
-	nvim --clean --headless -u scripts/minimal_init.lua +"PlenaryBustedFile $@ {minimal_init = 'scripts/minimal_init.lua'}"
-	
+	$(NVIM) --clean --headless -u scripts/minimal_init.lua +"PlenaryBustedFile $@ {minimal_init = 'scripts/minimal_init.lua'}"
+
 # We use mini.test for some end to end UI testing of session lens
 mini-tests: $(PLUGINS)
-	nvim --headless --noplugin -u scripts/minimal_init_mini.lua -c "lua MiniTest.run()"
+	$(NVIM) --headless --noplugin -u scripts/minimal_init_mini.lua -c "lua MiniTest.run()"
 
 $(PLENARY_DIR):
 	git clone --depth=1 --branch $(PLENARY_VER) $(PLENARY_URL) $@

--- a/README.md
+++ b/README.md
@@ -517,10 +517,12 @@ If that doesn't help, you can:
 
 # Compatibility
 
-Neovim > 0.7
+Neovim >= 0.10
+
+For support < 0.10, use tag pre-nvim-0.10
 
 Tested with:
 
 ```
-NVIM v0.7.2 - NVIM 0.11.2
+v0.10.3 - nightly
 ```


### PR DESCRIPTION
I looked into the GH action failures and they were caused by a non-deterministic error (sometimes segfault, sometimes LuaJIT assertion failure, sometimes works) in `restore_error_handler_spec.lua` with nvim < 0.10. I think it's time to drop support for those earlier versions.

They'll still work with the current build but I don't think we should commit to supporting them.

Separately, I added a macos testing target.

@rmagatti before this change is integrated, can you create a tag named `pre-nvim-0.10` (or whatever you'd prefer) that marks the last version of tested support for older versions?