### PR TITLE
fix(picker.select): fix loading/deleting

### DIFF
--- a/lua/auto-session/health.lua
+++ b/lua/auto-session/health.lua
@@ -104,6 +104,7 @@ function M.check()
   info("Session directory: " .. AutoSession.get_root_dir())
   info("Current session: " .. Lib.current_session_name())
   info("Current session file: " .. vim.v.this_session)
+  info("Selected picker: " .. require("auto-session.pickers").picker_name)
 end
 
 return M

--- a/lua/auto-session/pickers/fzf.lua
+++ b/lua/auto-session/pickers/fzf.lua
@@ -86,12 +86,11 @@ local function config_to_fzf_key_binding(config_keymap)
   local key = type(config_keymap) == "table" and config_keymap[2] or config_keymap
 
   ---@cast key string
-  key = key:lower()
 
-  key = key:gsub("<c%-", "ctrl-")
-  key = key:gsub("<s%-", "shift-")
-  key = key:gsub("<a%-", "alt-")
-  key = key:gsub("<m%-", "alt-")
+  key = key:gsub("<[cC]%-", "ctrl-")
+  key = key:gsub("<[sS]%-", "shift-")
+  key = key:gsub("<[aA]%-", "alt-")
+  key = key:gsub("<[mM]%-", "alt-")
 
   -- Remove angle brackets
   key = key:gsub("[<>]", "")

--- a/lua/auto-session/pickers/init.lua
+++ b/lua/auto-session/pickers/init.lua
@@ -37,10 +37,7 @@ end
 
 return setmetatable(M, {
   __index = function(table, key)
-    if
-      (key == "picker" and not rawget(table, "picker"))
-      or (key == "picker_name" and not rawget(table, "picker_name"))
-    then
+    if (key == "picker" or key == "picker_name") and not rawget(table, key) then
       local picker, picker_name = resolve_picker()
       rawset(table, "picker", picker)
       rawset(table, "picker_name", picker_name)

--- a/lua/auto-session/pickers/init.lua
+++ b/lua/auto-session/pickers/init.lua
@@ -8,27 +8,27 @@ local Lib = require "auto-session.lib"
 local M = {
   ---@type Picker
   picker = nil,
+  picker_name = nil,
 }
 
 ---Find an available picker. If Config.session_lens.picker is set, check that.
 ---Otherwise, check pickers in order to see which is available
 ---Fall back to vim.ui.select
----@return Picker # chosen picker
+---@return Picker,string # chosen picker and it's string name
 local function resolve_picker()
-  local pickers = Config.session_lens.picker and { Config.session_lens.picker, "select" }
+  local pickers = Config.session_lens.picker and { Config.session_lens.picker }
     or { "telescope", "fzf", "snacks", "select" }
 
   for _, name in ipairs(pickers) do
     local ok, picker = pcall(require, "auto-session.pickers." .. name)
     if ok and picker and picker.is_available() then
       Lib.logger.debug("Picking picker: " .. name)
-      return picker
+      return picker, name
     end
   end
 
-  -- should never get here
-  Lib.logger.error "Could not find any pickers?"
-  return require "auto-session.pickers.select"
+  Lib.logger.error("Could not find requested picker: " .. Config.session_lens.picker)
+  return require "auto-session.pickers.select", "select"
 end
 
 function M.open_session_picker()
@@ -37,8 +37,13 @@ end
 
 return setmetatable(M, {
   __index = function(table, key)
-    if key == "picker" and not rawget(table, "picker") then
-      rawset(table, "picker", resolve_picker())
+    if
+      (key == "picker" and not rawget(table, "picker"))
+      or (key == "picker_name" and not rawget(table, "picker_name"))
+    then
+      local picker, picker_name = resolve_picker()
+      rawset(table, "picker", picker)
+      rawset(table, "picker_name", picker_name)
     end
     return rawget(table, key)
   end,

--- a/lua/auto-session/pickers/select.lua
+++ b/lua/auto-session/pickers/select.lua
@@ -29,7 +29,7 @@ local function open_picker(files, prompt, callback)
 end
 
 ---Opens a vim.ui.select picker for loading sessions
-local function open_delete_picker()
+local function open_session_picker()
   local files = Lib.get_session_list(AutoSession.get_root_dir())
   open_picker(files, "Select a session:", function(choice)
     -- Defer session loading function to fix issue with Fzf and terminal sessions:
@@ -41,7 +41,7 @@ local function open_delete_picker()
 end
 
 ---Opens a vim.ui.select picker for deleting sessions
-local function open_session_picker()
+local function open_delete_picker()
   local files = Lib.get_session_list(AutoSession.get_root_dir())
   open_picker(files, "Delete a session:", function(choice)
     AutoSession.DeleteSessionFile(choice.path, choice.display_name)

--- a/tests/mini-tests/test_ui.lua
+++ b/tests/mini-tests/test_ui.lua
@@ -91,7 +91,21 @@ local function make_tests(picker, autosession_config, other_config)
     expect.equality(1, child.fn.bufexists(TL.other_file))
   end
 
-  if picker ~= "select" then
+  if picker == "select" then
+    T["session lens"]["can delete a session"] = function()
+      expect.equality(1, vim.fn.filereadable(TL.named_session_path))
+      child.cmd "Autosession delete"
+      vim.loop.sleep(300)
+      child.type_keys "mysession"
+      -- print(child.get_screenshot())
+      vim.loop.sleep(300)
+      child.type_keys "<cr>"
+      sleep_wait(2000, function()
+        return vim.fn.filereadable(TL.named_session_path) == 0
+      end, 100)
+      expect.equality(0, vim.fn.filereadable(TL.named_session_path))
+    end
+  else
     T["session lens"]["can copy a session"] = function()
       expect.equality(0, child.fn.bufexists(TL.test_file))
       child.cmd "SessionSearch"

--- a/tests/mini-tests/test_ui.lua
+++ b/tests/mini-tests/test_ui.lua
@@ -6,7 +6,7 @@ local expect, eq = MiniTest.expect, MiniTest.expect.equality
 local TL = require "tests/test_lib"
 
 -- Factory function to generate tests with different configs
-local function make_tests(autosession_config, other_config)
+local function make_tests(picker, autosession_config, other_config)
   -- Create (but not start) child Neovim object
   local child = MiniTest.new_child_neovim()
 
@@ -34,6 +34,25 @@ local function make_tests(autosession_config, other_config)
     },
   }
 
+  ---manual timeout function that works with MiniTest
+  ---@param timeout integer timeout in ms
+  ---@param fun function(): any
+  ---@param interval? integer sleep time in ms
+  ---@return any # return from fun
+  local function sleep_wait(timeout, fun, interval)
+    -- time functions don't seem to tick in MiniTest, manually calculate required iterations
+    local iterations = math.ceil(timeout / interval)
+
+    for _ = 0, iterations do
+      if fun() then
+        return true
+      end
+      vim.loop.sleep(interval)
+    end
+
+    return fun()
+  end
+
   T["session lens"] = new_set {}
 
   T["session lens"]["save a default session"] = function()
@@ -51,52 +70,61 @@ local function make_tests(autosession_config, other_config)
     child.cmd("SessionSave " .. TL.named_session_name)
     expect.equality(1, vim.fn.filereadable(TL.named_session_path))
 
+    child.cmd "%bw!"
+
     child.cmd("e " .. TL.other_file)
     child.cmd "SessionSave project_x"
   end
 
   T["session lens"]["can load a session"] = function()
-    expect.equality(0, child.fn.bufexists(TL.test_file))
+    expect.equality(0, child.fn.bufexists(TL.other_file))
     child.cmd "SessionSearch"
-    vim.loop.sleep(350)
-    -- print(child.get_screenshot())
+    vim.loop.sleep(300)
     child.type_keys "project_x"
+    -- print(child.get_screenshot())
+    vim.loop.sleep(300)
     child.type_keys "<cr>"
-    vim.wait(2000, function()
+    sleep_wait(2000, function()
       return child.fn.bufexists(TL.other_file) == 1
     end, 100)
+    -- print(child.get_screenshot())
     expect.equality(1, child.fn.bufexists(TL.other_file))
   end
 
-  T["session lens"]["can copy a session"] = function()
-    expect.equality(0, child.fn.bufexists(TL.test_file))
-    child.cmd "SessionSearch"
-    local session_name = "project_x"
-    vim.loop.sleep(350)
-    child.type_keys(session_name)
-    vim.loop.sleep(20)
-    child.type_keys "<C-Y>"
-    vim.loop.sleep(20)
+  if picker ~= "select" then
+    T["session lens"]["can copy a session"] = function()
+      expect.equality(0, child.fn.bufexists(TL.test_file))
+      child.cmd "SessionSearch"
+      local session_name = "project_x"
+      vim.loop.sleep(300)
+      child.type_keys(session_name)
+      vim.loop.sleep(100)
+      child.type_keys "<C-Y>"
+      vim.loop.sleep(100)
+      -- print(child.get_screenshot())
+      local copy_name = "copy"
+      child.type_keys(copy_name .. "<cr>")
+      local filepath = TL.makeSessionPath(session_name .. copy_name)
+      -- print(child.get_screenshot())
+      sleep_wait(2000, function()
+        return vim.fn.filereadable(filepath) == 1
+      end, 100)
+      expect.equality(1, vim.fn.filereadable(filepath))
+    end
 
-    local copy_name = "copy"
-    child.type_keys(copy_name .. "<cr>")
-    local filepath = TL.makeSessionPath(session_name .. copy_name)
-    vim.wait(2000, function()
-      return vim.fn.filereadable(filepath) == 1
-    end, 100)
-    expect.equality(1, vim.fn.filereadable(filepath))
-  end
-
-  T["session lens"]["can delete a session"] = function()
-    expect.equality(1, vim.fn.filereadable(TL.named_session_path))
-    child.cmd "SessionSearch"
-    vim.loop.sleep(350)
-    child.type_keys "mysession"
-    child.type_keys "<c-d>"
-    vim.wait(2000, function()
-      return vim.fn.filereadable(TL.named_session_path) == 0
-    end, 100)
-    expect.equality(0, vim.fn.filereadable(TL.named_session_path))
+    T["session lens"]["can delete a session"] = function()
+      expect.equality(1, vim.fn.filereadable(TL.named_session_path))
+      child.cmd "SessionSearch"
+      vim.loop.sleep(300)
+      child.type_keys "mysession"
+      -- print(child.get_screenshot())
+      vim.loop.sleep(300)
+      child.type_keys "<c-d>"
+      sleep_wait(2000, function()
+        return vim.fn.filereadable(TL.named_session_path) == 0
+      end, 100)
+      expect.equality(0, vim.fn.filereadable(TL.named_session_path))
+    end
   end
 
   return T
@@ -107,7 +135,10 @@ local combined = new_set {}
 local pickers = {
   { "telescope", "require('telescope').setup()" },
   { "snacks", "require('snacks').setup({picker = {enabled = true}})" },
-  -- can't test select because it blocks for input which hangs the test
+
+  -- need snacks to hook select otherwise it blocks the tests.
+  -- doing this let us test our select code
+  { "select", "require('snacks').setup({picker = {enabled = true}})" },
 }
 
 if vim.fn.executable "fzf" == 1 then
@@ -115,7 +146,7 @@ if vim.fn.executable "fzf" == 1 then
 end
 
 for _, picker in ipairs(pickers) do
-  combined["tests with picker " .. picker[1]] = make_tests({
+  combined["tests with picker " .. picker[1]] = make_tests(picker[1], {
     auto_save_enabled = false,
     auto_restore_enabled = false,
     session_lens = {


### PR DESCRIPTION
Only happens if vim.ui.select is the chosen picker.

I somehow mixed up the functions when refactoring so it would open the delete picker when asked for the session picker!

Also show selected picker in checkhealth