### PR TITLE
chore: reformat without no_call_parentheses

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -3,4 +3,3 @@ line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
-no_call_parentheses = true

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ local defaults = {
 
   -- Misc
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
-  root_dir = vim.fn.stdpath "data" .. "/sessions/", -- Root dir where sessions will be stored
+  root_dir = vim.fn.stdpath("data") .. "/sessions/", -- Root dir where sessions will be stored
   show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
   restore_error_handler = nil, -- Function called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
   continue_restore_on_error = true, -- Keep loading the session even if there's an error
@@ -115,7 +115,7 @@ local defaults = {
 
     ---@type SessionControl
     session_control = {
-      control_dir = vim.fn.stdpath "data" .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
+      control_dir = vim.fn.stdpath("data") .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
       control_filename = "session_control.json", -- File name of the session control file
     },
   },

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,4 @@
-*auto-session.txt*            For Neovim           Last change: 2025 August 23
+*auto-session.txt*            For Neovim           Last change: 2025 August 25
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -113,7 +113,7 @@ Default settings (you don’t have to copy these into your config):
     
       -- Misc
       log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
-      root_dir = vim.fn.stdpath "data" .. "/sessions/", -- Root dir where sessions will be stored
+      root_dir = vim.fn.stdpath("data") .. "/sessions/", -- Root dir where sessions will be stored
       show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
       restore_error_handler = nil, -- Function called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
       continue_restore_on_error = true, -- Keep loading the session even if there's an error
@@ -136,7 +136,7 @@ Default settings (you don’t have to copy these into your config):
     
         ---@type SessionControl
         session_control = {
-          control_dir = vim.fn.stdpath "data" .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
+          control_dir = vim.fn.stdpath("data") .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
           control_filename = "session_control.json", -- File name of the session control file
         },
       },

--- a/lua/auto-session/autocmds.lua
+++ b/lua/auto-session/autocmds.lua
@@ -1,6 +1,6 @@
-local Lib = require "auto-session.lib"
-local Config = require "auto-session.config"
-local AutoSession = require "auto-session"
+local Lib = require("auto-session.lib")
+local Config = require("auto-session.config")
+local AutoSession = require("auto-session")
 
 ---@mod auto-session.commands Commands
 ---@brief [[
@@ -48,7 +48,7 @@ local function purge_orphaned_sessions()
   end
 
   if Lib.is_empty_table(orphaned_sessions) then
-    Lib.logger.info "Nothing to purge"
+    Lib.logger.info("Nothing to purge")
     return
   end
 
@@ -63,20 +63,20 @@ end
 
 local function setup_dirchanged_autocmds()
   if not Config.cwd_change_handling then
-    Lib.logger.debug "cwd_change_handling is disabled, skipping setting DirChangedPre and DirChanged autocmd handling"
+    Lib.logger.debug("cwd_change_handling is disabled, skipping setting DirChangedPre and DirChanged autocmd handling")
     return
   end
 
   vim.api.nvim_create_autocmd("DirChangedPre", {
     callback = function()
-      Lib.logger.debug "DirChangedPre"
-      Lib.logger.debug {
+      Lib.logger.debug("DirChangedPre")
+      Lib.logger.debug({
         cwd = vim.fn.getcwd(-1, -1),
         ---@diagnostic disable-next-line: undefined-field
         target = vim.v.event.directory,
         ["changed window"] = tostring(vim.v.event.changed_window),
         scope = vim.v.event.scope,
-      }
+      })
 
       -- Don't want to save session if dir change was triggered
       -- by a window change. This will corrupt the session data,
@@ -86,7 +86,7 @@ local function setup_dirchanged_autocmds()
       end
 
       if AutoSession.restore_in_progress or vim.g.SessionLoad then
-        Lib.logger.debug "DirChangedPre: restore_in_progress/vim.g.SessionLoad is true, ignoring this event"
+        Lib.logger.debug("DirChangedPre: restore_in_progress/vim.g.SessionLoad is true, ignoring this event")
         -- NOTE: We don't call the cwd_changed_hook here
         -- I think that's probably the right choice because I assume that event is mostly
         -- for preparing sessions for save/restoring but we don't want to do that when we're
@@ -95,7 +95,7 @@ local function setup_dirchanged_autocmds()
       end
 
       AutoSession.AutoSaveSession()
-      AutoSession.run_cmds "pre_cwd_changed"
+      AutoSession.run_cmds("pre_cwd_changed")
 
       -- Clear the current session, fixes #399
       vim.v.this_session = ""
@@ -105,7 +105,7 @@ local function setup_dirchanged_autocmds()
 
   vim.api.nvim_create_autocmd("DirChanged", {
     callback = function()
-      Lib.logger.debug "DirChanged"
+      Lib.logger.debug("DirChanged")
       Lib.logger.debug("  cwd: " .. vim.fn.getcwd(-1, -1))
       Lib.logger.debug("  changed window: " .. tostring(vim.v.event.changed_window))
       Lib.logger.debug("  scope: " .. vim.v.event.scope)
@@ -120,13 +120,13 @@ local function setup_dirchanged_autocmds()
         -- I think that's probably the right choice because I assume that event is mostly
         -- for preparing sessions for save/restoring but we don't want to do that when we're
         -- already restoring a session
-        Lib.logger.debug "DirChangedPre: restore_in_progress/vim.g.SessionLoad is true, ignoring this event"
+        Lib.logger.debug("DirChangedPre: restore_in_progress/vim.g.SessionLoad is true, ignoring this event")
         return
       end
 
       -- all buffers should've been deleted in `DirChangedPre`, something probably went wrong
       if Lib.has_open_buffers() then
-        Lib.logger.debug "Cancelling session restore"
+        Lib.logger.debug("Cancelling session restore")
         return
       end
 
@@ -136,7 +136,7 @@ local function setup_dirchanged_autocmds()
       -- the restore for the next run of the event loop
       vim.schedule(function()
         AutoSession.AutoRestoreSession()
-        AutoSession.run_cmds "post_cwd_changed"
+        AutoSession.run_cmds("post_cwd_changed")
       end)
     end,
     pattern = "global",
@@ -200,9 +200,9 @@ function M.setup_autocmds()
   })
 
   vim.api.nvim_create_user_command("Autosession", function(args)
-    if args.args:match "search" then
+    if args.args:match("search") then
       return require("auto-session.pickers").open_session_picker()
-    elseif args.args:match "delete" then
+    elseif args.args:match("delete") then
       return require("auto-session.pickers.select").open_delete_picker()
     end
   end, {
@@ -237,8 +237,8 @@ function M.setup_autocmds()
     callback = function()
       if vim.g.in_pager_mode then
         -- Don't auto restore session in pager mode
-        Lib.logger.debug "In pager mode, skipping auto restore"
-        AutoSession.run_cmds "no_restore"
+        Lib.logger.debug("In pager mode, skipping auto restore")
+        AutoSession.run_cmds("no_restore")
         return
       end
 
@@ -258,14 +258,14 @@ function M.setup_autocmds()
 
       if not lazy_view.visible() then
         -- Lazy isn't visible, load as usual
-        Lib.logger.debug "Lazy is loaded, but not visible, will try to restore session"
+        Lib.logger.debug("Lazy is loaded, but not visible, will try to restore session")
         AutoSession.start()
         return
       end
 
       -- If the Lazy window is visible, hold onto it for later
       lazy_view_win = lazy_view.view.win
-      Lib.logger.debug "Lazy window is still visible, waiting for it to close"
+      Lib.logger.debug("Lazy window is still visible, waiting for it to close")
     end,
   })
 
@@ -294,11 +294,11 @@ function M.setup_autocmds()
 
         if event.match ~= tostring(lazy_view_win) then
           -- A window was closed, but it wasn't Lazy's window so keep waiting
-          Lib.logger.debug "A window was closed but it was not Lazy, keep waiting"
+          Lib.logger.debug("A window was closed but it was not Lazy, keep waiting")
           return
         end
 
-        Lib.logger.debug "Lazy window was closed, restore the session!"
+        Lib.logger.debug("Lazy window was closed, restore the session!")
 
         -- Clear lazy_view_win so we stop processing future WinClosed events
         lazy_view_win = nil

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -120,7 +120,7 @@ local defaults = {
 
   -- Misc
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
-  root_dir = vim.fn.stdpath "data" .. "/sessions/", -- Root dir where sessions will be stored
+  root_dir = vim.fn.stdpath("data") .. "/sessions/", -- Root dir where sessions will be stored
   show_auto_restore_notif = false, -- Whether to show a notification when auto-restoring
   restore_error_handler = nil, -- Function called when there's an error restoring. By default, it ignores fold errors otherwise it displays the error and returns false to disable auto_save
   continue_restore_on_error = true, -- Keep loading the session even if there's an error
@@ -143,7 +143,7 @@ local defaults = {
 
     ---@type SessionControl
     session_control = {
-      control_dir = vim.fn.stdpath "data" .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
+      control_dir = vim.fn.stdpath("data") .. "/auto_session/", -- Auto session control dir, for control files, like alternating between two sessions with session-lens
       control_filename = "session_control.json", -- File name of the session control file
     },
   },
@@ -303,7 +303,7 @@ function M.check(logger, show_full_message)
           .. 'vim.o.sessionoptions="blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"\n'
       )
     else
-      logger.warn "vim.o.sessionoptions is missing buffers. \nUse `:checkhealth autosession` for more info."
+      logger.warn("vim.o.sessionoptions is missing buffers. \nUse `:checkhealth autosession` for more info.")
     end
     has_issues = true
   end
@@ -316,29 +316,29 @@ function M.check(logger, show_full_message)
           .. 'vim.o.sessionoptions="blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"\n'
       )
     else
-      logger.warn "vim.o.sessionoptions is missing localoptions. \nUse `:checkhealth autosession` for more info."
+      logger.warn("vim.o.sessionoptions is missing localoptions. \nUse `:checkhealth autosession` for more info.")
     end
     has_issues = true
   end
 
-  if M.purge_after_minutes and vim.fn.has "nvim-0.10" ~= 1 then
-    logger.warn "the purge_after_minutes options requires nvim >= 0.10"
+  if M.purge_after_minutes and vim.fn.has("nvim-0.10") ~= 1 then
+    logger.warn("the purge_after_minutes options requires nvim >= 0.10")
     has_issues = true
   end
 
   if not M.git_use_branch_name and M.git_auto_restore_on_branch_change then
-    logger.error "git_auto_restore_on_branch_change requires git_use_branch_name = true"
+    logger.error("git_auto_restore_on_branch_change requires git_use_branch_name = true")
     has_issues = true
   end
 
   if M.single_session_mode and M.cwd_change_handling then
-    logger.warn "single_session_mode and cwd_change_handling are conflicting options. Disabling single_session_mode."
+    logger.warn("single_session_mode and cwd_change_handling are conflicting options. Disabling single_session_mode.")
     M.single_session_mode = false
     has_issues = true
   end
 
   if M.session_lens.load_on_setup and M.session_lens.picker and M.session_lens.picker ~= "telescope" then
-    logger.warn 'session_lens.load_on_setup is not used with pickers other than "telescope"'
+    logger.warn('session_lens.load_on_setup is not used with pickers other than "telescope"')
     M.session_lens.load_on_setup = false
   end
 

--- a/lua/auto-session/git.lua
+++ b/lua/auto-session/git.lua
@@ -1,6 +1,6 @@
-local AutoSession = require "auto-session"
-local Config = require "auto-session.config"
-local Lib = require "auto-session.lib"
+local AutoSession = require("auto-session")
+local Config = require("auto-session.config")
+local Lib = require("auto-session.lib")
 
 local uv = vim.uv or vim.loop
 
@@ -63,7 +63,7 @@ end
 function M.start_watcher(cwd, towatch)
   if M.uv_git_watcher then
     M.uv_git_watcher:stop()
-    Lib.logger.debug "Git: stopped old watcher so we can start a new one"
+    Lib.logger.debug("Git: stopped old watcher so we can start a new one")
   end
 
   M.uv_git_watcher = assert(uv.new_fs_event())
@@ -78,7 +78,7 @@ function M.start_watcher(cwd, towatch)
     Lib.debounce(function(err)
       if err then
         vim.schedule(function()
-          Lib.logger.err "Error watching for git branch changes"
+          Lib.logger.err("Error watching for git branch changes")
         end)
         return
       end
@@ -101,7 +101,7 @@ function M.stop_watcher()
   end
 
   M.uv_git_watcher:stop()
-  Lib.logger.debug "Git: stopped watcher"
+  Lib.logger.debug("Git: stopped watcher")
   M.uv_git_watcher = nil
 end
 

--- a/lua/auto-session/health.lua
+++ b/lua/auto-session/health.lua
@@ -1,6 +1,6 @@
-local AutoSession = require "auto-session"
-local Lib = require "auto-session.lib"
-local Config = require "auto-session.config"
+local AutoSession = require("auto-session")
+local Lib = require("auto-session.lib")
+local Config = require("auto-session.config")
 
 local M = {}
 
@@ -22,7 +22,7 @@ local function check_lazy_settings()
     return
   end
 
-  start "Lazy.nvim settings"
+  start("Lazy.nvim settings")
 
   if not Config.lazy_support then
     warn(
@@ -31,7 +31,7 @@ local function check_lazy_settings()
         .. "`lazy_support = true,` to your config (or remove the line that's setting it to false)"
     )
   else
-    ok "Lazy.nvim support is enabled"
+    ok("Lazy.nvim support is enabled")
   end
 
   local plugins = lazy.plugins()
@@ -52,7 +52,7 @@ local function check_lazy_settings()
             ]]
         )
       else
-        ok "auto-session is not lazy loaded"
+        ok("auto-session is not lazy loaded")
       end
 
       return
@@ -61,7 +61,7 @@ local function check_lazy_settings()
 end
 
 local function check_config()
-  start "Config"
+  start("Config")
   local loggerObj = {
     error = error,
     info = info,
@@ -69,12 +69,12 @@ local function check_config()
   }
 
   if not Config.check(loggerObj, true) then
-    ok "No config issues detected"
+    ok("No config issues detected")
   end
 end
 
 function M.check()
-  start "Setup"
+  start("Setup")
   if not Config.root_dir or vim.tbl_isempty(Lib.logger) then
     error(
       "Setup was not called. Auto-session will not work unless you call setup() somewhere, e.g.:\n\n"
@@ -82,14 +82,14 @@ function M.check()
     )
     return
   else
-    ok "setup() called"
+    ok("setup() called")
   end
 
   check_lazy_settings()
 
   check_config()
 
-  start "Current Config"
+  start("Current Config")
   if Config.has_old_config then
     info(
       "You have old config names. You can update your config to:\n"
@@ -100,7 +100,7 @@ function M.check()
     info("\n" .. vim.inspect(Config.options_without_defaults))
   end
 
-  start "General Info"
+  start("General Info")
   info("Session directory: " .. AutoSession.get_root_dir())
   info("Current session: " .. Lib.current_session_name())
   info("Current session file: " .. vim.v.this_session)

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -1,5 +1,5 @@
-local Lib = require "auto-session.lib"
-local Config = require "auto-session.config"
+local Lib = require("auto-session.lib")
+local Config = require("auto-session.config")
 
 local uv = vim.uv or vim.loop
 
@@ -22,7 +22,7 @@ function AutoSession.setup(config)
   -- Set up single session mode if enabled
   if Config.single_session_mode then
     AutoSession.manually_named_session = true
-    Lib.logger.debug "Single session mode enabled"
+    Lib.logger.debug("Single session mode enabled")
   end
 
   require("auto-session.autocmds").setup_autocmds()
@@ -83,7 +83,7 @@ local function enabled_for_command_line_argv(is_save)
 
   -- If no args (or launch_argv has been unset, allow restoring/saving)
   if not launch_argv then
-    Lib.logger.debug "launch_argv is nil, saving/restoring enabled"
+    Lib.logger.debug("launch_argv is nil, saving/restoring enabled")
     return true
   end
 
@@ -93,7 +93,7 @@ local function enabled_for_command_line_argv(is_save)
 
   if argc == 0 then
     -- Launched with no args, saving is enabled
-    Lib.logger.debug "No arguments, saving/restoring enabled"
+    Lib.logger.debug("No arguments, saving/restoring enabled")
     return true
   end
 
@@ -105,12 +105,12 @@ local function enabled_for_command_line_argv(is_save)
   end
 
   if not Config.args_allow_files_auto_save then
-    Lib.logger.debug "args_allow_files_auto_save is false, not enabling restoring/saving"
+    Lib.logger.debug("args_allow_files_auto_save is false, not enabling restoring/saving")
     return false
   end
 
   if not is_save then
-    Lib.logger.debug "Not allowing restore when launched with argument"
+    Lib.logger.debug("Not allowing restore when launched with argument")
     return false
   end
 
@@ -120,7 +120,7 @@ local function enabled_for_command_line_argv(is_save)
     return ret
   end
 
-  Lib.logger.debug "Allowing possible save when launched with argument"
+  Lib.logger.debug("Allowing possible save when launched with argument")
   return true
 end
 
@@ -137,7 +137,7 @@ end
 
 local auto_save = function()
   if in_pager_mode() or in_headless_mode() or not enabled_for_command_line_argv(true) then
-    Lib.logger.debug "auto_save, pager, headless, or enabled_for_command_line_argv returned false"
+    Lib.logger.debug("auto_save, pager, headless, or enabled_for_command_line_argv returned false")
     return false
   end
 
@@ -170,12 +170,12 @@ local function bypass_save_by_filetype()
     end
 
     if local_return == false then
-      Lib.logger.debug "bypass_save_by_filetype: false"
+      Lib.logger.debug("bypass_save_by_filetype: false")
       return false
     end
   end
 
-  Lib.logger.debug "bypass_save_by_filetype: true"
+  Lib.logger.debug("bypass_save_by_filetype: true")
   return true
 end
 
@@ -187,11 +187,11 @@ local function suppress_session(session_dir)
   local cwd = session_dir or vim.fn.getcwd(-1, -1)
 
   if Lib.find_matching_directory(cwd, dirs) then
-    Lib.logger.debug "suppress_session found a match, suppressing"
+    Lib.logger.debug("suppress_session found a match, suppressing")
     return true
   end
 
-  Lib.logger.debug "suppress_session didn't find a match, returning false"
+  Lib.logger.debug("suppress_session didn't find a match, returning false")
   return false
 end
 
@@ -204,11 +204,11 @@ local function is_allowed_dir()
   local cwd = vim.fn.getcwd(-1, -1)
 
   if Lib.find_matching_directory(cwd, dirs) then
-    Lib.logger.debug "is_allowed_dir found a match, allowing"
+    Lib.logger.debug("is_allowed_dir found a match, allowing")
     return true
   end
 
-  Lib.logger.debug "is_allowed_dir didn't find a match, returning false"
+  Lib.logger.debug("is_allowed_dir didn't find a match, returning false")
   return false
 end
 
@@ -239,31 +239,31 @@ end
 
 local function auto_save_conditions_met()
   if not is_enabled() then
-    Lib.logger.debug "auto_save_conditions_met: is_enabled() is false, returning false"
+    Lib.logger.debug("auto_save_conditions_met: is_enabled() is false, returning false")
     return false
   end
 
   if not auto_save() then
-    Lib.logger.debug "auto_save_conditions_met: auto_save() is false, returning false"
+    Lib.logger.debug("auto_save_conditions_met: auto_save() is false, returning false")
     return false
   end
 
   if suppress_session() then
-    Lib.logger.debug "auto_save_conditions_met: suppress_session() is true, returning false"
+    Lib.logger.debug("auto_save_conditions_met: suppress_session() is true, returning false")
     return false
   end
 
   if not is_allowed_dir() then
-    Lib.logger.debug "auto_save_conditions_met: is_allowed_dir() is false, returning false"
+    Lib.logger.debug("auto_save_conditions_met: is_allowed_dir() is false, returning false")
     return false
   end
 
   if bypass_save_by_filetype() then
-    Lib.logger.debug "auto_save_conditions_met: bypass_save_by_filetype() is true, returning false"
+    Lib.logger.debug("auto_save_conditions_met: bypass_save_by_filetype() is true, returning false")
     return false
   end
 
-  Lib.logger.debug "auto_save_conditions_met: returning true"
+  Lib.logger.debug("auto_save_conditions_met: returning true")
   return true
 end
 
@@ -287,7 +287,7 @@ end
 ---@return boolean True if a session was saved
 function AutoSession.AutoSaveSession()
   if not auto_save_conditions_met() then
-    Lib.logger.debug "Auto save conditions not met"
+    Lib.logger.debug("Auto save conditions not met")
     return false
   end
 
@@ -302,7 +302,7 @@ function AutoSession.AutoSaveSession()
   if not is_auto_create_enabled() then
     local session_file_name = get_session_file_name(current_session)
     if vim.fn.filereadable(AutoSession.get_root_dir() .. session_file_name) == 0 then
-      Lib.logger.debug "Create not enabled and no existing session, not creating session"
+      Lib.logger.debug("Create not enabled and no existing session, not creating session")
       return false
     end
   end
@@ -310,7 +310,7 @@ function AutoSession.AutoSaveSession()
   if Config.auto_delete_empty_sessions and Lib.only_blank_buffers_left() then
     -- don't auto-delete the session unless we actually loaded a session
     if vim.v.this_session ~= "" then
-      vim.notify "would auto delete"
+      vim.notify("would auto delete")
       AutoSession.DeleteSession(current_session)
     end
     return false
@@ -365,7 +365,7 @@ end
 ---@param session_name string The name of the session being saved
 ---@return boolean Returns whether extra commands were saved
 local function save_extra_cmds(session_path, session_name)
-  local data = AutoSession.run_cmds "save_extra"
+  local data = AutoSession.run_cmds("save_extra")
   local extra_file = string.gsub(session_path, "%.vim$", "x.vim")
 
   -- data is a table of strings or tables, one for each hook function
@@ -551,7 +551,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
     -- We failed to load a session for the other directory. Unless session name matches cwd, we don't
     -- want to enable autosaving since it might replace the session for the cwd
     if vim.fn.getcwd(-1, -1) ~= session_name then
-      Lib.logger.debug "Not enabling autosave because launch argument didn't load session and doesn't match cwd"
+      Lib.logger.debug("Not enabling autosave because launch argument didn't load session and doesn't match cwd")
       Config.auto_save = false
     end
   else
@@ -561,7 +561,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
 
     -- Check to see if the last session feature is on
     if Config.auto_restore_last_session then
-      Lib.logger.debug "Last session is enabled, checking for session"
+      Lib.logger.debug("Last session is enabled, checking for session")
 
       local last_session_name = Lib.get_latest_session(AutoSession.get_root_dir())
       if last_session_name then
@@ -575,13 +575,13 @@ function AutoSession.auto_restore_session_at_vim_enter()
           return true
         end
       end
-      Lib.logger.debug "Failed to load last session"
+      Lib.logger.debug("Failed to load last session")
     end
   end
 
   -- No session was restored, dispatch no-restore hook
-  Lib.logger.debug "No session restored, call no_restore hooks"
-  AutoSession.run_cmds "no_restore"
+  Lib.logger.debug("No session restored, call no_restore hooks")
+  AutoSession.run_cmds("no_restore")
 
   return false
 end
@@ -626,7 +626,7 @@ function AutoSession.SaveSessionToDir(session_dir, session_name, show_message)
 
     if escaped_session_name ~= cwd_escaped_session_name then
       AutoSession.manually_named_session = true
-      Lib.logger.debug "Session is manually named"
+      Lib.logger.debug("Session is manually named")
     end
   end
 
@@ -634,12 +634,12 @@ function AutoSession.SaveSessionToDir(session_dir, session_name, show_message)
 
   Lib.close_ignored_filetypes(Config.close_filetypes_on_save)
 
-  AutoSession.run_cmds "pre_save"
+  AutoSession.run_cmds("pre_save")
 
   -- We don't want to save arguments to the session as that can cause issues
   -- with buffers that can't be removed from the session as they keep being
   -- added back through an argadd
-  vim.cmd "%argdelete"
+  vim.cmd("%argdelete")
 
   Lib.logger.debug("SaveSessionToDir writing session to: " .. session_path)
 
@@ -651,7 +651,7 @@ function AutoSession.SaveSessionToDir(session_dir, session_name, show_message)
 
   save_extra_cmds(session_path, session_name)
 
-  AutoSession.run_cmds "post_save"
+  AutoSession.run_cmds("post_save")
 
   -- session_name might be nil (e.g. when using cwd), unescape escaped_session_name instead
   Lib.logger.debug("Saved session: " .. Lib.unescape_session_name(escaped_session_name))
@@ -705,7 +705,7 @@ function AutoSession.RestoreSessionFromDir(session_dir, session_name, opts)
 
     if escaped_session_name ~= cwd_escaped_session_name then
       AutoSession.manually_named_session = true
-      Lib.logger.debug "Session is manually named"
+      Lib.logger.debug("Session is manually named")
     end
   end
 
@@ -759,7 +759,7 @@ end
 local function restore_error_handler(error_msg)
   -- Ignore fold errors as discussed in https://github.com/rmagatti/auto-session/issues/409
   if error_msg and (string.find(error_msg, "E490: No fold found") or string.find(error_msg, "E16: Invalid range")) then
-    Lib.logger.debug "Ignoring fold error on restore"
+    Lib.logger.debug("Ignoring fold error on restore")
     return true
   end
 
@@ -777,7 +777,7 @@ function AutoSession.RestoreSessionFile(session_path, opts)
   Lib.logger.debug("RestoreSessionFile restoring session from: " .. session_path)
   opts = opts or {}
 
-  AutoSession.run_cmds "pre_restore"
+  AutoSession.run_cmds("pre_restore")
 
   -- Stop any language servers if config is set but don't do
   -- this on startup as it causes a perceptible delay (and we
@@ -812,7 +812,7 @@ function AutoSession.RestoreSessionFile(session_path, opts)
 
   -- Clear the buffers and jumps
   Lib.conditional_buffer_wipeout(Config.preserve_buffer_on_restore)
-  vim.cmd "silent clearjumps"
+  vim.cmd("silent clearjumps")
 
   ---@diagnostic disable-next-line: param-type-mismatch
   local success, result = pcall(vim.cmd, "silent " .. cmd)
@@ -820,7 +820,7 @@ function AutoSession.RestoreSessionFile(session_path, opts)
   -- normal restore failed, source again but with silent! to restore as much as possible
   if not success and Config.continue_restore_on_error then
     Lib.conditional_buffer_wipeout(Config.preserve_buffer_on_restore)
-    vim.cmd "silent clearjumps"
+    vim.cmd("silent clearjumps")
 
     -- don't capture return values as we'll use success and result from the first call
     ---@diagnostic disable-next-line: param-type-mismatch
@@ -842,7 +842,7 @@ function AutoSession.RestoreSessionFile(session_path, opts)
     local error_handler = type(Config.restore_error_handler) == "function" and Config.restore_error_handler
       or restore_error_handler
     if not error_handler(result) then
-      Lib.logger.debug "Error while restoring, disabling autosave"
+      Lib.logger.debug("Error while restoring, disabling autosave")
       Config.auto_save = false
       return false
     end
@@ -859,7 +859,7 @@ function AutoSession.RestoreSessionFile(session_path, opts)
     require("auto-session.git").start_watcher(vim.fn.getcwd(-1, -1), ".git/HEAD")
   end
 
-  AutoSession.run_cmds "post_restore"
+  AutoSession.run_cmds("post_restore")
 
   write_to_session_control_json(session_path)
   return true
@@ -913,7 +913,7 @@ end
 ---@param session_name string Session name being deleted, just use to display messages
 ---@return boolean # Was the session file deleted
 function AutoSession.DeleteSessionFile(session_path, session_name)
-  AutoSession.run_cmds "pre_delete"
+  AutoSession.run_cmds("pre_delete")
 
   Lib.logger.debug("DeleteSessionFile deleting: " .. session_path)
 
@@ -940,7 +940,7 @@ function AutoSession.DeleteSessionFile(session_path, session_name)
     Lib.logger.debug("DeleteSessionFile deleting extra user commands: " .. extra_commands_path)
   end
 
-  AutoSession.run_cmds "post_delete"
+  AutoSession.run_cmds("post_delete")
   return result
 end
 
@@ -950,9 +950,9 @@ end
 function AutoSession.DisableAutoSave(enable)
   Config.auto_save = enable or false
   if Config.auto_save then
-    vim.notify "Session auto-save enabled"
+    vim.notify("Session auto-save enabled")
   else
-    vim.notify "Session auto-save disabled"
+    vim.notify("Session auto-save disabled")
   end
   return Config.auto_save
 end

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -1,4 +1,4 @@
-local Logger = require "auto-session.logger"
+local Logger = require("auto-session.logger")
 
 local Lib = {
   logger = {},
@@ -7,9 +7,9 @@ local Lib = {
 }
 
 function Lib.setup(log_level)
-  Lib.logger = Logger:new {
+  Lib.logger = Logger:new({
     log_level = log_level,
-  }
+  })
 end
 
 local uv = vim.uv or vim.loop
@@ -59,7 +59,7 @@ function Lib.validate_root_dir(root_dir)
     -- NOTE: I don't think the code below will ever be triggered because the call to mkdir
     -- above will throw an error if it can't make the directory
     if vim.fn.isdirectory(Lib.expand(root_dir)) == Lib._VIM_FALSE then
-      local fallback = vim.fn.stdpath "data" .. "/sessions/"
+      local fallback = vim.fn.stdpath("data") .. "/sessions/"
       vim.cmd(
         "echoerr 'Invalid auto_session_root_dir. "
           .. "Path does not exist or is not a directory. "
@@ -86,7 +86,7 @@ function Lib.ensure_trailing_separator(dir)
   end
 
   -- For windows, have to also check if it ends in a \
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     if vim.endswith(dir, "\\") then
       return dir
     end
@@ -104,7 +104,7 @@ end
 ---@return string Dir guaranteed to not have a trailing separator
 function Lib.remove_trailing_separator(dir)
   -- For windows, have to check for both as either could be used
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     dir = dir:gsub("\\$", "")
   end
 
@@ -142,7 +142,7 @@ local function legacy_win32_escaped_dir(dir)
   return dir
 end
 
-local IS_WIN32 = vim.fn.has "win32" == Lib._VIM_TRUE
+local IS_WIN32 = vim.fn.has("win32") == Lib._VIM_TRUE
 
 -- Modified from: https://gist.github.com/liukun/f9ce7d6d14fa45fe9b924a3eed5c3d99
 ---Converts a character to it's hex representation
@@ -230,11 +230,11 @@ end
 function Lib.is_legacy_file_name(file_name)
   -- print(file_name)
   if IS_WIN32 then
-    return file_name:match "^[%a]++" ~= nil
+    return file_name:match("^[%a]++") ~= nil
   end
 
   -- if it's all alphanumeric, it's not
-  if file_name:match "^[%w]+%.vim$" then
+  if file_name:match("^[%w]+%.vim$") then
     return false
   end
 
@@ -249,9 +249,9 @@ function Lib.is_legacy_file_name(file_name)
 
   -- check each characters after each % to make sure
   -- they're hexadecimal
-  for encoded in file_name:gmatch "%%.." do
+  for encoded in file_name:gmatch("%%..") do
     local hex = encoded:sub(2)
-    if not hex:match "^%x%x$" then
+    if not hex:match("^%x%x$") then
       return true
     end
   end
@@ -291,9 +291,9 @@ function Lib.has_open_buffers()
         if vim.fn.bufwinnr(bufnr) ~= -1 then
           if result then
             result = true
-            Lib.logger.debug "There are buffer(s) present: "
+            Lib.logger.debug("There are buffer(s) present: ")
           end
-          Lib.logger.debug { bufname = bufname }
+          Lib.logger.debug({ bufname = bufname })
         end
       end
     end
@@ -309,7 +309,7 @@ function Lib.close_unsupported_windows()
     local windows = vim.api.nvim_tabpage_list_wins(tabpage)
     for _, window in ipairs(windows) do
       -- Never try to close the last window of the last tab
-      if vim.fn.tabpagenr "$" == 1 and vim.fn.winnr "$" == 1 then
+      if vim.fn.tabpagenr("$") == 1 and vim.fn.winnr("$") == 1 then
         return
       end
       -- Sometimes closing one window can affect another so wrap in pcall
@@ -385,13 +385,13 @@ end
 ---generated from a directory
 function Lib.is_named_session(session_file_name)
   Lib.logger.debug("session_file_name: " .. session_file_name)
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     -- Matches any letter followed by a colon
-    return not session_file_name:find "^%a:"
+    return not session_file_name:find("^%a:")
   end
 
   -- Matches / at the start of the string
-  return not session_file_name:find "^/.*"
+  return not session_file_name:find("^/.*")
 end
 
 ---When saving a session file, we may save an additional <filename>x.vim file
@@ -416,7 +416,7 @@ function Lib.is_session_file(session_path)
     return false
   end
 
-  local first_line = file:read "*line"
+  local first_line = file:read("*line")
   file:close()
 
   return first_line and string.find(first_line, "SessionLoad") ~= nil
@@ -540,7 +540,7 @@ function Lib.find_matching_directory(dirToFind, dirs)
       -- Lib.logger.debug("find_matching_directory simplified: " .. simplified_path)
 
       if dirToFind == path_without_trailing_slashes then
-        Lib.logger.debug "find find_matching_directory found match!"
+        Lib.logger.debug("find find_matching_directory found match!")
         return true
       end
     end
@@ -600,7 +600,7 @@ function Lib.flatten_table_and_split_strings(input)
     if value_type == "number" then
       table.insert(output, value)
     elseif value_type == "string" then
-      for s in value:gmatch "[^\r\n]+" do
+      for s in value:gmatch("[^\r\n]+") do
         table.insert(output, s)
       end
     end
@@ -707,7 +707,7 @@ end
 ---@return string|nil name of the alternate session, suitable for calls to LoadSession
 function Lib.get_alternate_session_name(session_control_conf)
   if not session_control_conf then
-    Lib.logger.error "No session_control in config!"
+    Lib.logger.error("No session_control in config!")
     return nil
   end
 
@@ -727,7 +727,7 @@ function Lib.get_alternate_session_name(session_control_conf)
   Lib.logger.debug("get_alternate_session_name", { sessions = sessions, json = json })
 
   if sessions.current == sessions.alternate then
-    Lib.logger.info "Current session is the same as alternate, returning nil"
+    Lib.logger.info("Current session is the same as alternate, returning nil")
     return nil
   end
   local file_name = vim.fn.fnamemodify(sessions.alternate, ":t")
@@ -895,7 +895,7 @@ end
 ---@param should_preserve_buffer fun(bufnr:number): preserve_buffer:boolean
 function Lib.conditional_buffer_wipeout(should_preserve_buffer)
   if not should_preserve_buffer then
-    vim.cmd "silent %bw!"
+    vim.cmd("silent %bw!")
     return
   end
 

--- a/lua/auto-session/pickers/fzf.lua
+++ b/lua/auto-session/pickers/fzf.lua
@@ -1,9 +1,9 @@
-local Config = require "auto-session.config"
-local Lib = require "auto-session.lib"
-local AutoSession = require "auto-session"
+local Config = require("auto-session.config")
+local Lib = require("auto-session.lib")
+local AutoSession = require("auto-session")
 
 local function is_available()
-  if vim.fn.exists ":FzfLua" ~= 2 then
+  if vim.fn.exists(":FzfLua") ~= 2 then
     return false
   end
 
@@ -16,7 +16,7 @@ end
 ---@return table|nil
 local function find_session_by_display_name(selected)
   if not selected or #selected == 0 then
-    Lib.logger.error "No session selected?"
+    Lib.logger.error("No session selected?")
     return
   end
 
@@ -99,7 +99,7 @@ local function config_to_fzf_key_binding(config_keymap)
 end
 
 local function open_session_picker()
-  local fzf_lua = require "fzf-lua"
+  local fzf_lua = require("fzf-lua")
   local keymaps = Config.session_lens.mappings or {}
 
   fzf_lua.fzf_exec(function(fzf_cb)

--- a/lua/auto-session/pickers/init.lua
+++ b/lua/auto-session/pickers/init.lua
@@ -1,5 +1,5 @@
-local Config = require "auto-session.config"
-local Lib = require "auto-session.lib"
+local Config = require("auto-session.config")
+local Lib = require("auto-session.lib")
 
 ---@class Picker
 ---@field is_available fun(): boolean
@@ -28,7 +28,7 @@ local function resolve_picker()
   end
 
   Lib.logger.error("Could not find requested picker: " .. Config.session_lens.picker)
-  return require "auto-session.pickers.select", "select"
+  return require("auto-session.pickers.select"), "select"
 end
 
 function M.open_session_picker()

--- a/lua/auto-session/pickers/select.lua
+++ b/lua/auto-session/pickers/select.lua
@@ -1,5 +1,5 @@
-local Lib = require "auto-session.lib"
-local AutoSession = require "auto-session"
+local Lib = require("auto-session.lib")
+local AutoSession = require("auto-session")
 
 local function is_available()
   return true

--- a/lua/auto-session/pickers/snacks.lua
+++ b/lua/auto-session/pickers/snacks.lua
@@ -1,6 +1,6 @@
-local Config = require "auto-session.config"
-local Lib = require "auto-session.lib"
-local AutoSession = require "auto-session"
+local Config = require("auto-session.config")
+local Lib = require("auto-session.lib")
+local AutoSession = require("auto-session")
 
 local function is_available()
   local success, snacks_picker_enabled = pcall(function()
@@ -19,7 +19,7 @@ local function open_session_picker()
     layout = { preset = "select" }
   end
 
-  Snacks.picker.pick {
+  Snacks.picker.pick({
     title = "Sessions",
     finder = function()
       return Lib.get_session_list(AutoSession.get_root_dir())
@@ -78,7 +78,7 @@ local function open_session_picker()
         end)
       end,
     },
-  }
+  })
 end
 
 ---@type Picker

--- a/lua/auto-session/pickers/telescope.lua
+++ b/lua/auto-session/pickers/telescope.lua
@@ -1,11 +1,11 @@
-local Config = require "auto-session.config"
-local Lib = require "auto-session.lib"
-local AutoSession = require "auto-session"
+local Config = require("auto-session.config")
+local Lib = require("auto-session.lib")
+local AutoSession = require("auto-session")
 
 local function is_available()
   -- don't just want to see if the telescope files are there,
   -- want to make sure it's loaded/configured
-  if vim.fn.exists ":Telescope" ~= 2 then
+  if vim.fn.exists(":Telescope") ~= 2 then
     return false
   end
 
@@ -21,7 +21,7 @@ local function is_available()
 end
 
 local function open_session_picker()
-  return vim.cmd "Telescope session-lens"
+  return vim.cmd("Telescope session-lens")
 end
 
 ---@private
@@ -29,9 +29,9 @@ end
 ---Triggers the customized telescope picker for switching sessions
 ---@param custom_opts table
 local function extension_search_session(custom_opts)
-  local telescope_themes = require "telescope.themes"
-  local telescope_actions = require "telescope.actions"
-  local telescope_finders = require "telescope.finders"
+  local telescope_themes = require("telescope.themes")
+  local telescope_actions = require("telescope.actions")
+  local telescope_finders = require("telescope.finders")
   local telescope_conf = require("telescope.config").values
 
   -- use custom_opts if specified and non-empty. Otherwise use the config
@@ -85,7 +85,7 @@ local function extension_search_session(custom_opts)
           return session_entry.display_name
         end
 
-        local telescope_utils = require "telescope.utils"
+        local telescope_utils = require("telescope.utils")
 
         return telescope_utils.transform_path(theme_opts, session_entry.display_name_component)
           .. session_entry.annotation_component
@@ -94,13 +94,13 @@ local function extension_search_session(custom_opts)
   end
 
   local finder_maker = function()
-    return telescope_finders.new_table {
+    return telescope_finders.new_table({
       results = Lib.get_session_list(session_root_dir),
       entry_maker = session_entry_maker,
-    }
+    })
   end
 
-  local Actions = require "auto-session.pickers.telescope_actions"
+  local Actions = require("auto-session.pickers.telescope_actions")
   local opts = {
     prompt_title = "Sessions",
     attach_mappings = function(prompt_bufnr, map)
@@ -111,13 +111,13 @@ local function extension_search_session(custom_opts)
         map(mappings.delete_session[1], mappings.delete_session[2], Actions.delete_session)
         map(mappings.alternate_session[1], mappings.alternate_session[2], Actions.alternate_session)
 
-        Actions.copy_session:enhance {
+        Actions.copy_session:enhance({
           post = function()
-            local action_state = require "telescope.actions.state"
+            local action_state = require("telescope.actions.state")
             local picker = action_state.get_current_picker(prompt_bufnr)
             picker:refresh(finder_maker(), { reset_prompt = true })
           end,
-        }
+        })
 
         map(mappings.copy_session[1], mappings.copy_session[2], Actions.copy_session)
       end

--- a/lua/auto-session/pickers/telescope_actions.lua
+++ b/lua/auto-session/pickers/telescope_actions.lua
@@ -1,6 +1,6 @@
-local AutoSession = require "auto-session"
-local Config = require "auto-session.config"
-local Lib = require "auto-session.lib"
+local AutoSession = require("auto-session")
+local Config = require("auto-session.config")
+local Lib = require("auto-session.lib")
 local transform_mod = require("telescope.actions.mt").transform_mod
 
 local M = {}
@@ -9,7 +9,7 @@ local M = {}
 
 local function source_session(session_name, prompt_bufnr)
   if prompt_bufnr then
-    local actions = require "telescope.actions"
+    local actions = require("telescope.actions")
     actions.close(prompt_bufnr)
   end
 
@@ -23,7 +23,7 @@ end
 ---Source a selected session after doing proper current session saving and cleanup
 ---@param prompt_bufnr number the telescope prompt bufnr
 M.source_session = function(prompt_bufnr)
-  local action_state = require "telescope.actions.state"
+  local action_state = require("telescope.actions.state")
   local selection = action_state.get_selected_entry()
   if selection then
     source_session(selection.value, prompt_bufnr)
@@ -35,7 +35,7 @@ end
 ---Delete a selected session file
 ---@param prompt_bufnr number the telescope prompt bufnr
 M.delete_session = function(prompt_bufnr)
-  local action_state = require "telescope.actions.state"
+  local action_state = require("telescope.actions.state")
   local current_picker = action_state.get_current_picker(prompt_bufnr)
   current_picker:delete_selection(function(selection)
     if selection then
@@ -48,7 +48,7 @@ end
 M.alternate_session = function(prompt_bufnr)
   local alternate_session_name = Lib.get_alternate_session_name(Config.session_lens.session_control)
   if not alternate_session_name then
-    vim.notify "There is no alternate session"
+    vim.notify("There is no alternate session")
     -- Keep the picker open in case they want to select a session to load
     return
   end
@@ -60,7 +60,7 @@ end
 ---Copy session action
 ---Ask user for the new name and then copy the session to that name
 M.copy_session = function(_)
-  local action_state = require "telescope.actions.state"
+  local action_state = require("telescope.actions.state")
   local selection = action_state.get_selected_entry()
 
   local new_name = vim.fn.input("New session name: ", selection.session_name)

--- a/lua/telescope/_extensions/session-lens.lua
+++ b/lua/telescope/_extensions/session-lens.lua
@@ -1,7 +1,7 @@
-local telescope = require "telescope"
-local Picker = require "auto-session.pickers.telescope"
+local telescope = require("telescope")
+local Picker = require("auto-session.pickers.telescope")
 
-return telescope.register_extension {
+return telescope.register_extension({
   setup = function()
     -- Nothing here for now
   end,
@@ -9,4 +9,4 @@ return telescope.register_extension {
     search_session = Picker.extension_search_session,
     ["session-lens"] = Picker.extension_search_session,
   },
-}
+})

--- a/scripts/lazy_init.lua
+++ b/scripts/lazy_init.lua
@@ -2,10 +2,10 @@
 -- See minimal_init.lua for more info
 
 vim.env.LAZY_STDPATH = ".test"
-load(vim.fn.system "curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua")()
+load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
 -- Setup lazy.nvim
-require("lazy.minit").setup {
+require("lazy.minit").setup({
   root = "./.test/plugins",
   spec = {
     --  FIXME: Using my fork of plenary just for https://github.com/nvim-lua/plenary.nvim/pull/611
@@ -18,4 +18,4 @@ require("lazy.minit").setup {
     { "folke/snacks.nvim", version = "v2.22.0" },
     { "ibhagwan/fzf-lua", commit = "71fe5c1" },
   },
-}
+})

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -10,7 +10,7 @@ local root = vim.fn.fnamemodify("./.test", ":p")
 local plugin_root = ".test/plugins/"
 
 -- set stdpaths to use .test
-for _, name in ipairs { "config", "data", "state", "cache" } do
+for _, name in ipairs({ "config", "data", "state", "cache" }) do
   vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. name
 end
 
@@ -29,7 +29,7 @@ while handle do
 end
 
 -- Add current directory to 'runtimepath' so we can load auto-session
-vim.cmd [[let &rtp.=','.getcwd()]]
+vim.cmd([[let &rtp.=','.getcwd()]])
 
 -- make sure plenary is loaded
-require "plenary"
+require("plenary")

--- a/scripts/minimal_init_mini.lua
+++ b/scripts/minimal_init_mini.lua
@@ -1,10 +1,10 @@
-dofile "scripts/minimal_init.lua"
+dofile("scripts/minimal_init.lua")
 
 -- Set up 'mini.test'
-require("mini.test").setup {
+require("mini.test").setup({
   collect = {
     find_files = function()
       return vim.fn.globpath("tests/mini-tests", "**/test_*.lua", true, true)
     end,
   },
-}
+})

--- a/scripts/update_readme.lua
+++ b/scripts/update_readme.lua
@@ -47,20 +47,20 @@ local function update_readme()
   local readme_text = read_file(readme_path)
 
   -- Extract types section: from ---@class AutoSession.Config to next empty line
-  local types_section = config_text:match "(---@class%s+AutoSession%.Config.-)\n\n"
+  local types_section = config_text:match("(---@class%s+AutoSession%.Config.-)\n\n")
   if not types_section then
-    error "Types section not found"
+    error("Types section not found")
   end
 
   -- Extract config section: from 'local defaults = {' to matching closing '}'
-  local start_pos, end_pos = config_text:find "local%s+defaults%s*=%s*{"
+  local start_pos, end_pos = config_text:find("local%s+defaults%s*=%s*{")
   if not start_pos then
-    error "Config section start not found"
+    error("Config section start not found")
   end
 
   local close_pos = find_matching_brace(config_text, end_pos)
   if not close_pos then
-    error "Config section closing brace not found"
+    error("Config section closing brace not found")
   end
 
   local config_section = config_text:sub(start_pos, close_pos)
@@ -70,7 +70,7 @@ local function update_readme()
   readme_text = replace_section(readme_text, "<!-- config:start -->", "<!-- config:end -->", config_section)
 
   write_file(readme_path, readme_text)
-  print "README.md updated successfully"
+  print("README.md updated successfully")
 end
 
 update_readme()

--- a/tests/allowed_dirs_spec.lua
+++ b/tests/allowed_dirs_spec.lua
@@ -1,5 +1,5 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 TL.clearSessionFilesAndBuffers()
 
 describe("The allowed dirs config", function()
@@ -15,12 +15,12 @@ describe("The allowed dirs config", function()
     uv.chdir(original_cwd)
   end)
 
-  local as = require "auto-session"
-  local c = require "auto-session.config"
-  as.setup {
+  local as = require("auto-session")
+  local c = require("auto-session.config")
+  as.setup({
     auto_session_allowed_dirs = { "/dummy" },
     -- log_level = "debug",
-  }
+  })
   local cwd = vim.fn.getcwd()
 
   it("doesn't save a session for a non-allowed dir", function()
@@ -48,7 +48,7 @@ describe("The allowed dirs config", function()
     c.allowed_dirs = { vim.fn.getcwd() .. "/tests/*" }
 
     -- Change to a sub directory to see if it's allowed
-    vim.cmd "cd tests/test_files"
+    vim.cmd("cd tests/test_files")
 
     local session_path = TL.makeSessionPath(vim.fn.getcwd())
     assert.equals(0, vim.fn.filereadable(session_path))
@@ -59,15 +59,15 @@ describe("The allowed dirs config", function()
     assert.equals(1, vim.fn.filereadable(session_path))
   end)
 
-  if vim.fn.has "win32" == 0 then
+  if vim.fn.has("win32") == 0 then
     it("saves a session for an allowed dir with a symlink", function()
       vim.cmd("cd " .. cwd)
 
       vim.cmd("e " .. TL.test_file)
       c.allowed_dirs = { vim.fn.getcwd() .. "/tests/symlink-test" }
 
-      vim.fn.system "ln -snf test_files tests/symlink-test"
-      vim.cmd "cd tests/symlink-test"
+      vim.fn.system("ln -snf test_files tests/symlink-test")
+      vim.cmd("cd tests/symlink-test")
 
       local session_path = TL.makeSessionPath(vim.fn.getcwd())
       assert.equals(0, vim.fn.filereadable(session_path))

--- a/tests/args_files_enabled_spec.lua
+++ b/tests/args_files_enabled_spec.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
-local stub = require "luassert.stub"
+local TL = require("tests/test_lib")
+local stub = require("luassert.stub")
 
 describe("The args files enabled config", function()
   local no_restore_hook_called = false
-  require("auto-session").setup {
+  require("auto-session").setup({
     args_allow_single_directory = false,
     args_allow_files_auto_save = true,
 
@@ -15,16 +15,16 @@ describe("The args files enabled config", function()
         no_restore_hook_called = true
       end,
     },
-  }
+  })
 
-  local c = require "auto-session.config"
+  local c = require("auto-session.config")
 
   TL.clearSessionFilesAndBuffers()
 
   it("can save a session", function()
     vim.cmd("e " .. TL.test_file)
 
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -33,7 +33,7 @@ describe("The args files enabled config", function()
     TL.assertSessionHasFile(TL.default_session_path, TL.test_file)
 
     -- now clear the buffers
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
   end)
 
   it("doesn't restore a session when run with a single directory", function()
@@ -41,7 +41,7 @@ describe("The args files enabled config", function()
 
     -- Stub
     local s = stub(vim.fn, "argv")
-    s.returns { "." }
+    s.returns({ "." })
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())
@@ -59,7 +59,7 @@ describe("The args files enabled config", function()
     assert.equals(false, no_restore_hook_called)
 
     local s = stub(vim.fn, "argv")
-    s.returns { TL.other_file }
+    s.returns({ TL.other_file })
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())
@@ -76,7 +76,7 @@ describe("The args files enabled config", function()
     vim.cmd("e " .. TL.other_file)
     assert.equals(1, vim.fn.bufexists(TL.other_file))
 
-    local as = require "auto-session"
+    local as = require("auto-session")
 
     c.auto_save = true
 
@@ -97,7 +97,7 @@ describe("The args files enabled config", function()
     vim.cmd("e " .. TL.other_file)
     assert.equals(1, vim.fn.bufexists(TL.other_file))
 
-    local as = require "auto-session"
+    local as = require("auto-session")
 
     c.auto_save = true
     c.args_allow_files_auto_save = function()
@@ -118,7 +118,7 @@ describe("The args files enabled config", function()
     vim.cmd("e " .. TL.other_file)
     assert.equals(1, vim.fn.bufexists(TL.other_file))
 
-    local as = require "auto-session"
+    local as = require("auto-session")
 
     c.auto_save = true
     c.args_allow_files_auto_save = function()

--- a/tests/args_not_enabled_spec.lua
+++ b/tests/args_not_enabled_spec.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
-local stub = require "luassert.stub"
+local TL = require("tests/test_lib")
+local stub = require("luassert.stub")
 
 describe("The args not enabled config", function()
   local no_restore_hook_called = false
-  require("auto-session").setup {
+  require("auto-session").setup({
     args_allow_single_directory = false,
     args_allow_files_auto_save = false,
 
@@ -15,13 +15,13 @@ describe("The args not enabled config", function()
         no_restore_hook_called = true
       end,
     },
-  }
+  })
   TL.clearSessionFilesAndBuffers()
 
   it("can save a session", function()
     vim.cmd("e " .. TL.test_file)
 
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -30,7 +30,7 @@ describe("The args not enabled config", function()
     TL.assertSessionHasFile(TL.default_session_path, TL.test_file)
 
     -- now clear the buffers
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
   end)
 
   it("doesn't restore a session when run with a single directory", function()
@@ -38,7 +38,7 @@ describe("The args not enabled config", function()
 
     -- Stub
     local s = stub(vim.fn, "argv")
-    s.returns { "." }
+    s.returns({ "." })
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())
@@ -56,7 +56,7 @@ describe("The args not enabled config", function()
     assert.equals(false, no_restore_hook_called)
 
     local s = stub(vim.fn, "argv")
-    s.returns { TL.test_file }
+    s.returns({ TL.test_file })
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())

--- a/tests/args_single_dir_enabled_spec.lua
+++ b/tests/args_single_dir_enabled_spec.lua
@@ -1,13 +1,13 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
-local stub = require "luassert.stub"
+local TL = require("tests/test_lib")
+local stub = require("luassert.stub")
 
 describe("The args single dir enabled config", function()
   local no_restore_hook_called = false
-  local as = require "auto-session"
-  local c = require "auto-session.config"
+  local as = require("auto-session")
+  local c = require("auto-session.config")
 
-  as.setup {
+  as.setup({
     args_allow_single_directory = true,
     args_allow_files_auto_save = false,
 
@@ -19,13 +19,13 @@ describe("The args single dir enabled config", function()
       end,
     },
     -- log_level = "debug",
-  }
+  })
   TL.clearSessionFilesAndBuffers()
 
   it("can save a session", function()
     vim.cmd("e " .. TL.test_file)
 
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -34,7 +34,7 @@ describe("The args single dir enabled config", function()
     TL.assertSessionHasFile(TL.default_session_path, TL.test_file)
 
     -- now clear the buffers
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
   end)
 
   it("does not autosave for cwd if single directory arg does not have a session", function()
@@ -43,7 +43,7 @@ describe("The args single dir enabled config", function()
     c.auto_save = true
 
     local s = stub(vim.fn, "argv")
-    s.returns { "tests" }
+    s.returns({ "tests" })
 
     -- only exported because we set the unit testing env in TL
     assert.False(as.auto_restore_session_at_vim_enter())
@@ -63,11 +63,11 @@ describe("The args single dir enabled config", function()
     local cwd = vim.fn.getcwd()
 
     -- Change out of current directory so we don't load session for it
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
 
     -- Stub
     local s = stub(vim.fn, "argv")
-    s.returns { cwd }
+    s.returns({ cwd })
 
     -- only exported because we set the unit testing env in TL
     assert.equals(true, as.auto_restore_session_at_vim_enter())
@@ -81,12 +81,12 @@ describe("The args single dir enabled config", function()
   end)
 
   it("doesn't restore a session when run with a file", function()
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
     no_restore_hook_called = false
     assert.equals(false, no_restore_hook_called)
 
     local s = stub(vim.fn, "argv")
-    s.returns { TL.test_file }
+    s.returns({ TL.test_file })
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, as.auto_restore_session_at_vim_enter())

--- a/tests/auto_delete_spec.lua
+++ b/tests/auto_delete_spec.lua
@@ -1,12 +1,12 @@
-require "plenary"
-local TL = require "tests/test_lib"
+require("plenary")
+local TL = require("tests/test_lib")
 
 describe("auto_delete", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
 
-  as.setup {
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   it("doesn't delete a session with buffers", function()
     TL.clearSessionFilesAndBuffers()
@@ -18,7 +18,7 @@ describe("auto_delete", function()
   end)
 
   it("doesn't delete session when we never loaded a session", function()
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
     vim.v.this_session = ""
 
     assert.False(as.AutoSaveSession())
@@ -30,7 +30,7 @@ describe("auto_delete", function()
     vim.cmd("e " .. TL.test_file)
     assert.True(as.SaveSession())
 
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
 
     assert.False(as.AutoSaveSession())
 

--- a/tests/auto_save_spec.lua
+++ b/tests/auto_save_spec.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The auto_save_enabled=false config", function()
-  require("auto-session").setup {
+  require("auto-session").setup({
     auto_save_enabled = false,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -22,7 +22,7 @@ describe("The auto_save_enabled=false config", function()
     vim.cmd("e " .. TL.test_file)
 
     ---@diagnostic disable-next-line: missing-parameter
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))

--- a/tests/bypass_save_by_filetypes_spec.lua
+++ b/tests/bypass_save_by_filetypes_spec.lua
@@ -1,12 +1,12 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("Bypass save by filetypes", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
 
-  as.setup {
+  as.setup({
     bypass_session_save_file_types = { "text" },
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -29,7 +29,7 @@ describe("Bypass save by filetypes", function()
 
   it("does save when there are other filetypes", function()
     vim.cmd("e " .. TL.test_file)
-    vim.cmd "e tests/bypass_session_save_file_types.lua"
+    vim.cmd("e tests/bypass_session_save_file_types.lua")
 
     -- generate default session
     assert.True(as.AutoSaveSession())

--- a/tests/close_filetypes_on_save_spec.lua
+++ b/tests/close_filetypes_on_save_spec.lua
@@ -1,19 +1,19 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("Close filetypes on save", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
 
-  as.setup {
+  as.setup({
     -- use old config name
     ignore_filetypes_on_save = { "text" },
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
   it("closes buffers of matching filetypes before saving", function()
     vim.cmd("e " .. TL.test_file) -- this is a text file
-    vim.cmd "e tests/close_filetypes_on_save_spec.lua"
+    vim.cmd("e tests/close_filetypes_on_save_spec.lua")
 
     -- generate default session
     assert.True(as.AutoSaveSession())
@@ -29,11 +29,11 @@ describe("Close filetypes on save", function()
 
   it("does not close buffers of other filetypes", function()
     vim.cmd("e " .. TL.test_file) -- this is a text file
-    vim.cmd "e tests/close_filetypes_on_save_spec.lua"
+    vim.cmd("e tests/close_filetypes_on_save_spec.lua")
 
-    as.setup {
+    as.setup({
       close_filetypes_on_save = { "lua" },
-    }
+    })
 
     -- generate default session
     assert.True(as.AutoSaveSession())
@@ -49,11 +49,11 @@ describe("Close filetypes on save", function()
 
   it("does not save a checkhealth buffer", function()
     vim.cmd("e " .. TL.test_file) -- this is a text file
-    vim.cmd "checkhealth auto-session"
+    vim.cmd("checkhealth auto-session")
 
-    as.setup {
+    as.setup({
       close_filetypes_on_save = { "checkhealth" }, -- or empty if ignoring checkhealth is the default as suggested above
-    }
+    })
 
     -- generate default session
     assert.True(as.AutoSaveSession())

--- a/tests/cmds_custom_dir_spec.lua
+++ b/tests/cmds_custom_dir_spec.lua
@@ -1,11 +1,11 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The default config", function()
-  local as = require "auto-session"
-  as.setup {
+  local as = require("auto-session")
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   local custom_sessions_dir = vim.fn.getcwd() .. "/tests/custom_sessions/"
   local cwd_session_name = TL.escapeSessionName(vim.fn.getcwd())
@@ -31,7 +31,7 @@ describe("The default config", function()
   it("can restore a session for the cwd from a custom directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
@@ -65,7 +65,7 @@ describe("The default config", function()
   it("can restore a named session from a custom directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))

--- a/tests/cmds_enable_toggle_spec.lua
+++ b/tests/cmds_enable_toggle_spec.lua
@@ -1,12 +1,12 @@
 describe("The default config", function()
-  local as = require "auto-session"
-  local c = require "auto-session.config"
-  as.setup {}
+  local as = require("auto-session")
+  local c = require("auto-session.config")
+  as.setup({})
 
   it("can disable autosave", function()
     c.auto_save = true
 
-    vim.cmd "SessionDisableAutoSave"
+    vim.cmd("SessionDisableAutoSave")
 
     assert.False(c.auto_save)
   end)
@@ -14,16 +14,16 @@ describe("The default config", function()
   it("can enable autosave", function()
     c.auto_save = false
 
-    vim.cmd "SessionDisableAutoSave!"
+    vim.cmd("SessionDisableAutoSave!")
 
     assert.True(c.auto_save)
   end)
 
   it("can toggle autosave", function()
     assert.True(c.auto_save)
-    vim.cmd "SessionToggleAutoSave"
+    vim.cmd("SessionToggleAutoSave")
     assert.False(c.auto_save)
-    vim.cmd "SessionToggleAutoSave"
+    vim.cmd("SessionToggleAutoSave")
     assert.True(c.auto_save)
   end)
 end)

--- a/tests/cmds_spec.lua
+++ b/tests/cmds_spec.lua
@@ -1,19 +1,19 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The default config", function()
-  local as = require "auto-session"
-  local Lib = require "auto-session.lib"
-  local c = require "auto-session.config"
-  as.setup {
+  local as = require("auto-session")
+  local Lib = require("auto-session.lib")
+  local c = require("auto-session.config")
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
   it("doesn't crash when restoring with no sessions", function()
     ---@diagnostic disable-next-line: param-type-mismatch
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
   end)
@@ -22,7 +22,7 @@ describe("The default config", function()
     assert.False(as.session_exists_for_cwd())
     vim.cmd("e " .. TL.test_file)
 
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -46,12 +46,12 @@ describe("The default config", function()
   it("can restore a session for the cwd", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)
@@ -59,7 +59,7 @@ describe("The default config", function()
   it("can restore a session for the cwd using a session name", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
@@ -84,7 +84,7 @@ describe("The default config", function()
   it("can restore a named session", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
@@ -115,7 +115,7 @@ describe("The default config", function()
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
 
-    vim.cmd "SessionDelete"
+    vim.cmd("SessionDelete")
 
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))
   end)
@@ -161,12 +161,12 @@ describe("The default config", function()
   it("can restore the auto-saved session for the cwd", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
@@ -186,7 +186,7 @@ describe("The default config", function()
 
     as.DisableAutoSave()
 
-    vim.cmd "SessionPurgeOrphaned"
+    vim.cmd("SessionPurgeOrphaned")
     -- print(TL.default_session_path)
 
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -205,7 +205,7 @@ describe("The default config", function()
     assert.True(as.SaveSession())
 
     -- clear buffers so only an empty,unnamed buffer is left
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure session exists
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))

--- a/tests/create_enabled_spec.lua
+++ b/tests/create_enabled_spec.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The create_enabled=false config", function()
-  require("auto-session").setup {
+  require("auto-session").setup({
     auto_session_create_enabled = false,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -22,7 +22,7 @@ describe("The create_enabled=false config", function()
     vim.cmd("e " .. TL.test_file)
 
     ---@diagnostic disable-next-line: missing-parameter
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -34,12 +34,12 @@ describe("The create_enabled=false config", function()
   it("can restore a session ", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)
@@ -52,14 +52,14 @@ describe("The create_enabled=false config", function()
     -- Make sure the buffer is gone
     assert.equals(1, vim.fn.bufexists(TL.other_file))
 
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
     assert.equals(0, vim.fn.bufexists(TL.other_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
     assert.equals(1, vim.fn.bufexists(TL.other_file))
@@ -73,12 +73,12 @@ describe("The create_enabled=function config", function()
   -- NOTE: This second call to setup reuses the same auto-session object
   -- so it doesn't re-initialize the config to the default values so be
   -- careful of values set up in the first call
-  require("auto-session").setup {
+  require("auto-session").setup({
     auto_session_create_enabled = function()
       callback_called = true
       return allow_create
     end,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
   vim.cmd("e " .. TL.other_file)

--- a/tests/custom_session_tag_spec.lua
+++ b/tests/custom_session_tag_spec.lua
@@ -1,13 +1,13 @@
-require "plenary"
-local TL = require "tests/test_lib"
+require("plenary")
+local TL = require("tests/test_lib")
 
 describe("custom session tag", function()
-  local as = require "auto-session"
-  local c = require "auto-session.config"
+  local as = require("auto-session")
+  local c = require("auto-session.config")
 
-  as.setup {
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   it("can save and restore a session", function()
     TL.clearSessionFilesAndBuffers()
@@ -23,7 +23,7 @@ describe("custom session tag", function()
     assert.True(as.SaveSession())
     assert.equals(1, vim.fn.filereadable(session_path))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
     assert.True(as.RestoreSession())
     assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)

--- a/tests/cwd_change_handling_spec.lua
+++ b/tests/cwd_change_handling_spec.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The cwd_change_handling config", function()
   local pre_cwd_changed_hook_called = false
   local post_cwd_changed_hook_called = false
-  require("auto-session").setup {
+  require("auto-session").setup({
     -- log_level = "debug",
     cwd_change_handling = {
       restore_upcoming_session = true,
@@ -15,7 +15,7 @@ describe("The cwd_change_handling config", function()
         post_cwd_changed_hook_called = true
       end,
     },
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
   vim.cmd("e " .. TL.test_file)
@@ -39,7 +39,7 @@ describe("The cwd_change_handling config", function()
 
     assert.True(vim.v.this_session ~= "")
 
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
     vim.wait(0)
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
@@ -53,7 +53,7 @@ describe("The cwd_change_handling config", function()
   it("does load the session for the base dir", function()
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "cd .."
+    vim.cmd("cd ..")
     vim.wait(0)
 
     assert.equals(vim.fn.getcwd(), require("auto-session.lib").current_session_name())
@@ -63,7 +63,7 @@ describe("The cwd_change_handling config", function()
 
   it("does not double load a session when using SessionRestore", function()
     -- Move to different directory
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
     vim.wait(0)
 
     pre_cwd_changed_hook_called = false

--- a/tests/dotvim_spec.lua
+++ b/tests/dotvim_spec.lua
@@ -1,11 +1,11 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The default config", function()
-  local as = require "auto-session"
-  as.setup {
+  local as = require("auto-session")
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -22,7 +22,7 @@ describe("The default config", function()
   end)
 
   it("can restore a session name with .vim", function()
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 

--- a/tests/expanding_session_dir_spec.lua
+++ b/tests/expanding_session_dir_spec.lua
@@ -1,5 +1,5 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 local custom_session_dir = "/tests/custom_sessions/"
 
@@ -10,17 +10,17 @@ describe("A custom session dir config", function()
   -- Get path that requires expanding
   local expanding_path = vim.fn.fnamemodify(vim.fn.getcwd() .. custom_session_dir, ":~")
 
-  local as = require "auto-session"
-  as.setup {
+  local as = require("auto-session")
+  as.setup({
     auto_session_root_dir = expanding_path,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
   vim.cmd("e " .. TL.test_file)
 
   it("can save default session to the directory", function()
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
@@ -40,12 +40,12 @@ describe("A custom session dir config", function()
   it("can load default session from the directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)
@@ -69,7 +69,7 @@ describe("A custom session dir config", function()
   it("can load a named session from the directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))

--- a/tests/extra_data_spec.lua
+++ b/tests/extra_data_spec.lua
@@ -1,13 +1,13 @@
-require "plenary"
-local TL = require "tests/test_lib"
+require("plenary")
+local TL = require("tests/test_lib")
 
 describe("extra data", function()
-  local as = require "auto-session"
-  local c = require "auto-session.config"
+  local as = require("auto-session")
+  local c = require("auto-session.config")
 
-  as.setup {
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   it("can be saved and restored", function()
     vim.cmd("e " .. TL.test_file)

--- a/tests/extra_sesssion_commands_spec.lua
+++ b/tests/extra_sesssion_commands_spec.lua
@@ -1,13 +1,13 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 TL.clearSessionFilesAndBuffers()
 
 describe("Config with extra session commands", function()
   local save_extra_cmds_called = false
-  local as = require "auto-session"
-  local Lib = require "auto-session.lib"
+  local as = require("auto-session")
+  local Lib = require("auto-session.lib")
   -- WARN: this test calls setup again later to change save_extra_cmds
-  as.setup {
+  as.setup({
     save_extra_cmds = {
       function()
         save_extra_cmds_called = true
@@ -18,7 +18,7 @@ describe("Config with extra session commands", function()
       end,
     },
     -- log_level = "debug",
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -58,9 +58,9 @@ describe("Config with extra session commands", function()
     assert.equals(1, vim.fn.filereadable(default_extra_cmds_path))
 
     -- remove the handler
-    as.setup {
+    as.setup({
       save_extra_cmds = nil,
-    }
+    })
 
     -- generate default session
     assert.True(as.AutoSaveSession())
@@ -79,14 +79,14 @@ describe("Config with extra session commands", function()
 
     save_extra_cmds_called = false
 
-    as.setup {
+    as.setup({
       save_extra_cmds = {
         function()
           save_extra_cmds_called = true
           return { "lua vim.g.extraCmdsTest = 1", "lua vim.g.extraCmdsTest2 = 2" }
         end,
       },
-    }
+    })
 
     -- generate default session
     assert.True(as.AutoSaveSession())
@@ -147,7 +147,7 @@ describe("Config with extra session commands", function()
   end)
 
   it("deletes a default session's extra commands when deleting the session", function()
-    vim.cmd "SessionDelete"
+    vim.cmd("SessionDelete")
 
     -- Make sure the session was deleted
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))

--- a/tests/get_cwd_spec.lua
+++ b/tests/get_cwd_spec.lua
@@ -1,9 +1,9 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("cwd lookup", function()
-  local as = require "auto-session"
-  require("auto-session").setup {}
+  local as = require("auto-session")
+  require("auto-session").setup({})
 
   before_each(function()
     TL.clearSessionFilesAndBuffers()
@@ -12,12 +12,12 @@ describe("cwd lookup", function()
   it("works when tcd is used", function()
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))
     vim.cmd("e " .. TL.test_file)
-    vim.cmd "tabnew"
-    vim.cmd "tcd tests"
+    vim.cmd("tabnew")
+    vim.cmd("tcd tests")
 
     as.SaveSession()
 
-    vim.cmd "tabclose"
+    vim.cmd("tabclose")
 
     -- Make sure the session was still created for the global directory
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -26,12 +26,12 @@ describe("cwd lookup", function()
   it("works when lcd is used", function()
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))
     vim.cmd("e " .. TL.test_file)
-    vim.cmd "tabnew"
-    vim.cmd "lcd tests"
+    vim.cmd("tabnew")
+    vim.cmd("lcd tests")
 
     assert.True(as.SaveSession())
 
-    vim.cmd "tabclose"
+    vim.cmd("tabclose")
 
     -- Make sure the session was still created for the global directory
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -1,20 +1,20 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
-local stub = require "luassert.stub"
+local TL = require("tests/test_lib")
+local stub = require("luassert.stub")
 
 describe("The git config", function()
-  local as = require "auto-session"
-  local Lib = require "auto-session.lib"
-  local c = require "auto-session.config"
+  local as = require("auto-session")
+  local Lib = require("auto-session.lib")
+  local c = require("auto-session.config")
   -- NOTE: need to load the git module here because we change the directory later which
   -- I think messes up the relative module load path. a bit of a hack but oh well
   ---@diagnostic disable-next-line: unused-local
-  local g = require "auto-session.git"
+  local g = require("auto-session.git")
 
-  as.setup {
+  as.setup({
     auto_session_use_git_branch = true,
     -- log_level = "debug",
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -29,7 +29,7 @@ describe("The git config", function()
   vim.cmd("e " .. TL.test_file)
   vim.cmd("w! " .. git_test_path .. "/test.txt")
   vim.cmd("w! " .. git_test_path .. "/other.txt")
-  vim.cmd "silent %bw"
+  vim.cmd("silent %bw")
 
   -- change to that dir
   vim.cmd("cd " .. git_test_path)
@@ -48,14 +48,14 @@ describe("The git config", function()
   end
 
   -- init repo and make a commit
-  runCmdAndPrint "git init -b main"
-  runCmdAndPrint 'git config user.email "test@test.com"'
-  runCmdAndPrint 'git config user.name "test"'
-  runCmdAndPrint "git add test.txt"
-  runCmdAndPrint "git commit -m 'init'"
+  runCmdAndPrint("git init -b main")
+  runCmdAndPrint('git config user.email "test@test.com"')
+  runCmdAndPrint('git config user.name "test"')
+  runCmdAndPrint("git add test.txt")
+  runCmdAndPrint("git commit -m 'init'")
 
   -- open a file so we have something to save
-  vim.cmd "e test.txt"
+  vim.cmd("e test.txt")
 
   local branch_session_path = TL.session_dir .. TL.escapeSessionName(vim.fn.getcwd() .. "|main") .. ".vim"
 
@@ -64,7 +64,7 @@ describe("The git config", function()
 
     as.AutoSaveSession()
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
 
     -- print(session_path)
     assert.equals(1, vim.fn.filereadable(branch_session_path))
@@ -80,18 +80,18 @@ describe("The git config", function()
   end)
 
   it("autorestores a session with the branch name", function()
-    vim.cmd "silent %bw!"
-    assert.equals(0, vim.fn.bufexists "test.txt")
+    vim.cmd("silent %bw!")
+    assert.equals(0, vim.fn.bufexists("test.txt"))
 
     as.AutoRestoreSession()
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
     assert.equals(1, vim.fn.filereadable(branch_session_path))
     assert.equals(vim.fn.getcwd() .. " (branch: main)", Lib.current_session_name())
   end)
 
   it("works with a custom session tag", function()
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
 
     local tag = "mytag"
     c.custom_session_tag = function()
@@ -100,8 +100,8 @@ describe("The git config", function()
 
     assert.True(as.SaveSession())
 
-    vim.cmd "silent %bw!"
-    assert.equals(0, vim.fn.bufexists "test.txt")
+    vim.cmd("silent %bw!")
+    assert.equals(0, vim.fn.bufexists("test.txt"))
     local branch_tag_session_path = TL.session_dir .. TL.escapeSessionName(vim.fn.getcwd() .. "|main|" .. tag) .. ".vim"
 
     assert.True(as.RestoreSession())
@@ -109,7 +109,7 @@ describe("The git config", function()
     -- unset this early so other tests don't also fail if the following checks fail
     c.custom_session_tag = nil
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
     assert.equals(1, vim.fn.filereadable(branch_tag_session_path), "file doesn't exist: " .. branch_tag_session_path)
     assert.equals(vim.fn.getcwd() .. " (branch: main, tag: " .. tag .. ")", Lib.current_session_name())
   end)
@@ -123,12 +123,12 @@ describe("The git config", function()
     assert.equals(1, vim.fn.filereadable(legacy_branch_session_path))
     assert.equals(0, vim.fn.filereadable(branch_session_path))
 
-    vim.cmd "silent %bw!"
-    assert.equals(0, vim.fn.bufexists "test.txt")
+    vim.cmd("silent %bw!")
+    assert.equals(0, vim.fn.bufexists("test.txt"))
 
     as.AutoRestoreSession()
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
 
     assert.equals(1, vim.fn.filereadable(branch_session_path))
     assert.equals(0, vim.fn.filereadable(legacy_branch_session_path))
@@ -137,7 +137,7 @@ describe("The git config", function()
   end)
 
   it("can get the session name of a git branch with a slash", function()
-    runCmdAndPrint "git checkout -b slash/branch"
+    runCmdAndPrint("git checkout -b slash/branch")
 
     as.SaveSession()
 
@@ -152,21 +152,21 @@ describe("The git config", function()
     c.log_level = "debug"
 
     -- delete all buffers
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     local s = stub(vim.fn, "argv")
-    s.returns { "." }
+    s.returns({ "." })
 
     -- only exported because we set the unit testing env in TL
     assert.True(as.auto_restore_session_at_vim_enter())
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
 
     -- Revert the stub
     vim.fn.argv:revert()
     c.auto_save = false
 
-    vim.fn.system "git switch main"
+    vim.fn.system("git switch main")
   end)
 
   it("load a session named with git branch from directory argument", function()
@@ -174,18 +174,18 @@ describe("The git config", function()
     c.cwd_change_handling = false
 
     -- delete all buffers
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- change to parent directory
-    vim.cmd "cd .."
+    vim.cmd("cd ..")
 
     local s = stub(vim.fn, "argv")
-    s.returns { git_test_dir }
+    s.returns({ git_test_dir })
 
     -- only exported because we set the unit testing env in TL
     assert.True(as.auto_restore_session_at_vim_enter())
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
 
     -- Revert the stub
     vim.fn.argv:revert()
@@ -197,17 +197,17 @@ describe("The git config", function()
     c.git_auto_restore_on_branch_change = true
 
     -- make sure we're on the main branch
-    vim.fn.system "git switch -c main"
+    vim.fn.system("git switch -c main")
 
     -- delete all buffers
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- branch change monitoring is only turned on when we've loaded a session
     as.RestoreSession()
     assert.equals("test_git (branch: main)", Lib.current_session_name(true))
 
     -- save main branch session
-    assert.equals(1, vim.fn.bufexists "test.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
     as.SaveSession()
 
     -- stub out on_git_watch_event so we know when the watcher is triggered
@@ -221,19 +221,19 @@ describe("The git config", function()
     end)
 
     -- switch to other-branch just to set it up
-    vim.fn.system "git switch -c other-branch"
+    vim.fn.system("git switch -c other-branch")
     vim.wait(1000, function()
       return git_watch_triggered
     end)
 
-    vim.cmd "silent %bw"
-    vim.cmd "e other.txt"
+    vim.cmd("silent %bw")
+    vim.cmd("e other.txt")
 
-    assert.equals(0, vim.fn.bufexists "test.txt")
-    assert.equals(1, vim.fn.bufexists "other.txt")
+    assert.equals(0, vim.fn.bufexists("test.txt"))
+    assert.equals(1, vim.fn.bufexists("other.txt"))
 
     git_watch_triggered = false
-    vim.fn.system "git switch main"
+    vim.fn.system("git switch main")
     vim.wait(1000, function()
       return git_watch_triggered
     end)
@@ -241,18 +241,18 @@ describe("The git config", function()
     assert.equals("test_git (branch: main)", Lib.current_session_name(true))
     -- other branch should now exist but the main branch is our current session
 
-    assert.equals(1, vim.fn.bufexists "test.txt")
-    assert.equals(0, vim.fn.bufexists "other.txt")
+    assert.equals(1, vim.fn.bufexists("test.txt"))
+    assert.equals(0, vim.fn.bufexists("other.txt"))
 
     git_watch_triggered = false
-    vim.fn.system "git switch other-branch"
+    vim.fn.system("git switch other-branch")
     vim.wait(1000, function()
       return git_watch_triggered
     end)
 
     assert.equals("test_git (branch: other-branch)", Lib.current_session_name(true))
-    assert.equals(0, vim.fn.bufexists "test.txt")
-    assert.equals(1, vim.fn.bufexists "other.txt")
+    assert.equals(0, vim.fn.bufexists("test.txt"))
+    assert.equals(1, vim.fn.bufexists("other.txt"))
 
     c.auto_save = false
     g.on_git_watch_event:revert()

--- a/tests/hooks_spec.lua
+++ b/tests/hooks_spec.lua
@@ -1,8 +1,8 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("Hooks", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
   local pre_save_cmd_called = false
   local post_save_cmd_called = false
   local pre_restore_cmd_called = false
@@ -10,17 +10,17 @@ describe("Hooks", function()
   local pre_delete_cmd_called = false
   local post_delete_cmd_called = false
 
-  as.setup {
+  as.setup({
     pre_save_cmds = {
       function()
-        print "pre_save_cmd"
+        print("pre_save_cmd")
         pre_save_cmd_called = true
         assert.equals(0, vim.fn.filereadable(TL.default_session_path))
       end,
     },
     post_save_cmds = {
       function()
-        print "post_save_cmd"
+        print("post_save_cmd")
         post_save_cmd_called = true
         assert.equals(1, vim.fn.filereadable(TL.default_session_path))
       end,
@@ -52,7 +52,7 @@ describe("Hooks", function()
 
     -- save_extra is covered by extra_session_commands
     -- no_restore is covered by args tests
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -67,7 +67,7 @@ describe("Hooks", function()
   end)
 
   it("fire when restoring", function()
-    vim.cmd "%bw"
+    vim.cmd("%bw")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))

--- a/tests/last_session_spec.lua
+++ b/tests/last_session_spec.lua
@@ -1,16 +1,16 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The last loaded session config", function()
-  require("auto-session").setup {
+  require("auto-session").setup({
     auto_session_enable_last_session = true,
     auto_save_enabled = false,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
   it("doesn't crash when restoring with no sessions", function()
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
   end)
@@ -18,7 +18,7 @@ describe("The last loaded session config", function()
   it("can save a session for the cwd", function()
     vim.cmd("e " .. TL.test_file)
 
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
@@ -28,7 +28,7 @@ describe("The last loaded session config", function()
   end)
 
   it("can save a named sessions with another file", function()
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
     vim.cmd("e " .. TL.other_file)
@@ -47,14 +47,14 @@ describe("The last loaded session config", function()
 
   it("doesn't restore the last session when doing a normal SessionRestore", function()
     -- switch to directory that doesn't have a session
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
     assert.equals(0, vim.fn.bufexists(TL.test_file))
     assert.equals(0, vim.fn.bufexists(TL.other_file))
 
     -- WARN: this test below also expects to be run from the tests directory
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     -- Have file from latest session
     assert.equals(0, vim.fn.bufexists(TL.other_file))
@@ -65,7 +65,7 @@ describe("The last loaded session config", function()
 
   it("does restores the last session when doing an auto-restore", function()
     -- switch to directory that doesn't have a session
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
     assert.equals(0, vim.fn.bufexists(TL.test_file))
     assert.equals(0, vim.fn.bufexists(TL.other_file))
 

--- a/tests/legacy_file_names_spec.lua
+++ b/tests/legacy_file_names_spec.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("Legacy file name support", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
   local save_extra_cmds_called = false
-  as.setup {
+  as.setup({
     -- log_level = "debug",
     save_extra_cmds = {
       function()
@@ -12,7 +12,7 @@ describe("Legacy file name support", function()
         return [[echo "hello world"]]
       end,
     },
-  }
+  })
   local default_extra_cmds_path = TL.default_session_path:gsub("%.vim$", "x.vim")
   local legacy_extra_cmds_path = TL.default_session_path_legacy:gsub("%.vim$", "x.vim")
 
@@ -40,7 +40,7 @@ describe("Legacy file name support", function()
     assert.equals(1, vim.fn.filereadable(legacy_extra_cmds_path))
     assert.equals(0, vim.fn.filereadable(default_extra_cmds_path))
 
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
@@ -78,7 +78,7 @@ describe("Legacy file name support", function()
     assert.equals(1, vim.fn.filereadable(TL.default_session_path_legacy))
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))
 
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 

--- a/tests/lib_spec.lua
+++ b/tests/lib_spec.lua
@@ -1,11 +1,11 @@
 ---@diagnostic disable: undefined-field, redundant-parameter
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("Lib / Helper functions", function()
-  local as = require "auto-session"
-  as.setup {}
+  local as = require("auto-session")
+  as.setup({})
 
-  local Lib = require "auto-session.lib"
+  local Lib = require("auto-session.lib")
 
   TL.clearSessionFilesAndBuffers()
 
@@ -14,7 +14,7 @@ describe("Lib / Helper functions", function()
 
     local session_dir_no_slash = TL.session_dir:gsub("/$", "")
 
-    if vim.fn.has "win32" then
+    if vim.fn.has("win32") then
       session_dir_no_slash = session_dir_no_slash:gsub("\\$", "")
     end
 
@@ -22,25 +22,25 @@ describe("Lib / Helper functions", function()
   end)
 
   it("remove_trailing_separator works", function()
-    assert.equals("/tmp/blah", Lib.remove_trailing_separator "/tmp/blah/")
-    assert.equals("/tmp/blah", Lib.remove_trailing_separator "/tmp/blah")
-    assert.equals("/", Lib.remove_trailing_separator "/")
+    assert.equals("/tmp/blah", Lib.remove_trailing_separator("/tmp/blah/"))
+    assert.equals("/tmp/blah", Lib.remove_trailing_separator("/tmp/blah"))
+    assert.equals("/", Lib.remove_trailing_separator("/"))
 
-    if vim.fn.has "win32" == 1 then
-      assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator "c:\\temp\\blah\\")
-      assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator "c:\\temp\\blah/")
-      assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator "c:\\temp\\blah")
+    if vim.fn.has("win32") == 1 then
+      assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator("c:\\temp\\blah\\"))
+      assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator("c:\\temp\\blah/"))
+      assert.equals("c:\\temp\\blah", Lib.remove_trailing_separator("c:\\temp\\blah"))
     end
   end)
 
   it("ensure_trailing_separator works", function()
-    assert.equals("/test/path/", Lib.ensure_trailing_separator "/test/path/")
-    assert.equals("/test/path/", Lib.ensure_trailing_separator "/test/path")
+    assert.equals("/test/path/", Lib.ensure_trailing_separator("/test/path/"))
+    assert.equals("/test/path/", Lib.ensure_trailing_separator("/test/path"))
 
-    if vim.fn.has "win32" == 1 then
+    if vim.fn.has("win32") == 1 then
       -- For the future, if we want to canonicalize paths, we can could call vim.fn.expand
-      assert.equals("c:\\test\\path\\", Lib.ensure_trailing_separator "c:\\test\\path\\")
-      assert.equals("c:\\test\\path/", Lib.ensure_trailing_separator "c:\\test\\path")
+      assert.equals("c:\\test\\path\\", Lib.ensure_trailing_separator("c:\\test\\path\\"))
+      assert.equals("c:\\test\\path/", Lib.ensure_trailing_separator("c:\\test\\path"))
     end
   end)
 
@@ -52,23 +52,23 @@ describe("Lib / Helper functions", function()
   end)
 
   it("can percent encode/decode", function()
-    assert.equals("%2Fsome%2Fdir%2Fwith%20spaces%2Fand-dashes", Lib.percent_encode "/some/dir/with spaces/and-dashes")
+    assert.equals("%2Fsome%2Fdir%2Fwith%20spaces%2Fand-dashes", Lib.percent_encode("/some/dir/with spaces/and-dashes"))
     assert.equals(
       "/some/dir/with spaces/and-dashes",
-      Lib.percent_decode(Lib.percent_encode "/some/dir/with spaces/and-dashes")
+      Lib.percent_decode(Lib.percent_encode("/some/dir/with spaces/and-dashes"))
     )
 
     assert.equals(
       "c%3A%5Csome%5Cdir%5Cwith%20space%5Cand-dashes%5C",
-      Lib.percent_encode "c:\\some\\dir\\with space\\and-dashes\\"
+      Lib.percent_encode("c:\\some\\dir\\with space\\and-dashes\\")
     )
     assert.equals(
       "c:\\some\\dir\\with space\\and-dashes\\",
-      Lib.percent_decode(Lib.percent_encode "c:\\some\\dir\\with space\\and-dashes\\")
+      Lib.percent_decode(Lib.percent_encode("c:\\some\\dir\\with space\\and-dashes\\"))
     )
 
-    assert.equals("percent%25test", Lib.percent_encode "percent%test")
-    assert.equals("percent%test", Lib.percent_decode "percent%25test")
+    assert.equals("percent%25test", Lib.percent_encode("percent%test"))
+    assert.equals("percent%test", Lib.percent_decode("percent%25test"))
 
     -- round trip should be stable
     assert.equals(TL.default_session_name, Lib.percent_decode(Lib.percent_encode(TL.default_session_name)))
@@ -80,94 +80,94 @@ describe("Lib / Helper functions", function()
   end)
 
   it("session_file_name_to_session_name() works", function()
-    assert.equals("mysession", Lib.escaped_session_name_to_session_name "mysession.vim")
-    assert.equals("mysessionavim", Lib.escaped_session_name_to_session_name "mysessionavim")
-    assert.equals("mysession", Lib.escaped_session_name_to_session_name "mysession")
+    assert.equals("mysession", Lib.escaped_session_name_to_session_name("mysession.vim"))
+    assert.equals("mysessionavim", Lib.escaped_session_name_to_session_name("mysessionavim"))
+    assert.equals("mysession", Lib.escaped_session_name_to_session_name("mysession"))
   end)
 
   it("is_named_session() works", function()
-    assert.True(Lib.is_named_session "mysession")
-    assert.True(Lib.is_named_session "mysession.vim")
+    assert.True(Lib.is_named_session("mysession"))
+    assert.True(Lib.is_named_session("mysession.vim"))
 
-    if vim.fn.has "win32" == 1 then
-      assert.False(Lib.is_named_session "C:\\some\\dir")
-      assert.False(Lib.is_named_session "C:/some/dir")
+    if vim.fn.has("win32") == 1 then
+      assert.False(Lib.is_named_session("C:\\some\\dir"))
+      assert.False(Lib.is_named_session("C:/some/dir"))
     else
-      assert.False(Lib.is_named_session "/some/dir")
+      assert.False(Lib.is_named_session("/some/dir"))
     end
   end)
 
   it("escape_session_name() works", function()
     assert.equals(
       "%2Fsome%2Fdir%2Fwith%20spaces%2Fand-dashes",
-      Lib.escape_session_name "/some/dir/with spaces/and-dashes"
+      Lib.escape_session_name("/some/dir/with spaces/and-dashes")
     )
 
     assert.equals(
       "c%3A%5Csome%5Cdir%5Cwith%20space%5Cand-dashes%5C",
-      Lib.escape_session_name "c:\\some\\dir\\with space\\and-dashes\\"
+      Lib.escape_session_name("c:\\some\\dir\\with space\\and-dashes\\")
     )
   end)
 
   it("legacy_escape_session_name() works", function()
-    if vim.fn.has "win32" == 1 then
+    if vim.fn.has("win32") == 1 then
       if vim.o.shellslash then
-        assert.equals("c++-some-dir-", Lib.legacy_escape_session_name "c:/some/dir/")
+        assert.equals("c++-some-dir-", Lib.legacy_escape_session_name("c:/some/dir/"))
       else
-        assert.equals("c++-some-dir-", Lib.legacy_escape_session_name "c:\\some\\dir\\")
+        assert.equals("c++-some-dir-", Lib.legacy_escape_session_name("c:\\some\\dir\\"))
       end
     else
-      assert.equals("%some%dir%", Lib.legacy_escape_session_name "/some/dir/")
+      assert.equals("%some%dir%", Lib.legacy_escape_session_name("/some/dir/"))
     end
   end)
 
   it("legacy_escape_session_name() works", function()
-    if vim.fn.has "win32" == 1 then
+    if vim.fn.has("win32") == 1 then
       if vim.o.shellslash then
-        assert.equals("c:/some/dir/", Lib.legacy_unescape_session_name "c++-some-dir-")
+        assert.equals("c:/some/dir/", Lib.legacy_unescape_session_name("c++-some-dir-"))
       else
-        assert.equals("c:\\some\\dir\\", Lib.legacy_unescape_session_name "c++-some-dir-")
+        assert.equals("c:\\some\\dir\\", Lib.legacy_unescape_session_name("c++-some-dir-"))
       end
     else
-      assert.equals("/some/dir/", Lib.legacy_unescape_session_name "%some%dir%")
+      assert.equals("/some/dir/", Lib.legacy_unescape_session_name("%some%dir%"))
     end
   end)
 
   it("escape_string_for_vim() works", function()
-    assert.equals("\\%some\\%dir\\%", Lib.escape_string_for_vim "%some%dir%")
+    assert.equals("\\%some\\%dir\\%", Lib.escape_string_for_vim("%some%dir%"))
   end)
 
   it("can identify new and old sessions", function()
-    assert.False(Lib.is_legacy_file_name(Lib.percent_encode "mysession" .. ".vim"))
-    assert.False(Lib.is_legacy_file_name(Lib.percent_encode "/some/dir/" .. ".vim"))
-    assert.False(Lib.is_legacy_file_name(Lib.percent_encode "/some/dir/with spaces/and-dashes" .. ".vim"))
-    assert.False(Lib.is_legacy_file_name(Lib.percent_encode "c:\\some\\dir\\with spaces\\and-dashes" .. ".vim"))
-    assert.False(Lib.is_legacy_file_name(Lib.percent_encode "c:\\some\\dir\\with spaces\\and-dashes\\" .. ".vim"))
+    assert.False(Lib.is_legacy_file_name(Lib.percent_encode("mysession") .. ".vim"))
+    assert.False(Lib.is_legacy_file_name(Lib.percent_encode("/some/dir/") .. ".vim"))
+    assert.False(Lib.is_legacy_file_name(Lib.percent_encode("/some/dir/with spaces/and-dashes") .. ".vim"))
+    assert.False(Lib.is_legacy_file_name(Lib.percent_encode("c:\\some\\dir\\with spaces\\and-dashes") .. ".vim"))
+    assert.False(Lib.is_legacy_file_name(Lib.percent_encode("c:\\some\\dir\\with spaces\\and-dashes\\") .. ".vim"))
 
-    assert.False(Lib.is_legacy_file_name(TL.legacyEscapeSessionName "mysession" .. ".vim"))
+    assert.False(Lib.is_legacy_file_name(TL.legacyEscapeSessionName("mysession") .. ".vim"))
 
-    if vim.fn.has "win32" == 1 then
-      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName "c:\\some\\dir" .. ".vim"))
-      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName "c:\\some\\other\\dir" .. ".vim"))
-      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName "c:\\some\\dir-with-dashes" .. ".vim"))
-      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName "c:/some/dir-with-dashes" .. ".vim"))
+    if vim.fn.has("win32") == 1 then
+      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName("c:\\some\\dir") .. ".vim"))
+      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName("c:\\some\\other\\dir") .. ".vim"))
+      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName("c:\\some\\dir-with-dashes") .. ".vim"))
+      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName("c:/some/dir-with-dashes") .. ".vim"))
     else
-      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName "/some/dir" .. ".vim"))
+      assert.True(Lib.is_legacy_file_name(TL.legacyEscapeSessionName("/some/dir") .. ".vim"))
     end
   end)
 
   it("can get display name", function()
-    local splits = Lib.get_session_display_name_as_table "%2FUsers%2Fcam%2FDev%2Fneovim-dev%2Fauto-session.vim"
+    local splits = Lib.get_session_display_name_as_table("%2FUsers%2Fcam%2FDev%2Fneovim-dev%2Fauto-session.vim")
 
     assert.equals(1, #splits)
     assert.equals("/Users/cam/Dev/neovim-dev/auto-session", splits[1])
 
     assert.equals(
       "/Users/cam/Dev/neovim-dev/auto-session",
-      (Lib.get_session_display_name "%2FUsers%2Fcam%2FDev%2Fneovim-dev%2Fauto-session.vim")
+      (Lib.get_session_display_name("%2FUsers%2Fcam%2FDev%2Fneovim-dev%2Fauto-session.vim"))
     )
 
-    splits = Lib.get_session_display_name_as_table "%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain.vim"
+    splits = Lib.get_session_display_name_as_table("%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain.vim")
 
     assert.equals(2, #splits)
     assert.equals("/Users/cam/tmp/a", splits[1])
@@ -175,12 +175,12 @@ describe("Lib / Helper functions", function()
 
     assert.equals(
       "/Users/cam/tmp/a (branch: main)",
-      (Lib.get_session_display_name "%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain.vim")
+      (Lib.get_session_display_name("%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain.vim"))
     )
   end)
 
   it("display names with custom tags work", function()
-    local splits = Lib.get_session_display_name_as_table "%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain%7Cmytag.vim"
+    local splits = Lib.get_session_display_name_as_table("%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain%7Cmytag.vim")
 
     assert.equals(2, #splits)
     assert.equals("/Users/cam/tmp/a", splits[1])
@@ -188,10 +188,10 @@ describe("Lib / Helper functions", function()
 
     assert.equals(
       "/Users/cam/tmp/a (branch: main, tag: mytag)",
-      (Lib.get_session_display_name "%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain%7Cmytag.vim")
+      (Lib.get_session_display_name("%2FUsers%2Fcam%2Ftmp%2Fa%7Cmain%7Cmytag.vim"))
     )
 
-    splits = Lib.get_session_display_name_as_table "%2FUsers%2Fcam%2Ftmp%2Fa%7C%7Cmytag.vim"
+    splits = Lib.get_session_display_name_as_table("%2FUsers%2Fcam%2Ftmp%2Fa%7C%7Cmytag.vim")
 
     assert.equals(2, #splits)
     assert.equals("/Users/cam/tmp/a", splits[1])
@@ -199,7 +199,7 @@ describe("Lib / Helper functions", function()
 
     assert.equals(
       "/Users/cam/tmp/a (tag: mytag)",
-      (Lib.get_session_display_name "%2FUsers%2Fcam%2Ftmp%2Fa%7C%7Cmytag.vim")
+      (Lib.get_session_display_name("%2FUsers%2Fcam%2Ftmp%2Fa%7C%7Cmytag.vim"))
     )
   end)
 

--- a/tests/ls_stop_on_restore_spec.lua
+++ b/tests/ls_stop_on_restore_spec.lua
@@ -1,19 +1,19 @@
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("lsp_stop_on_restore", function()
-  local as = require "auto-session"
-  as.setup {}
+  local as = require("auto-session")
+  as.setup({})
   TL.clearSessionFilesAndBuffers()
   vim.cmd("e " .. TL.test_file)
   as.SaveSession()
 
   it("calls user function on restore", function()
     local stop_called = false
-    as.setup {
+    as.setup({
       lsp_stop_on_restore = function()
         stop_called = true
       end,
-    }
+    })
 
     as.RestoreSession()
 
@@ -22,11 +22,11 @@ describe("lsp_stop_on_restore", function()
 
   it("doesn't try to stop ls on initial autorestore", function()
     local stop_called = false
-    as.setup {
+    as.setup({
       lsp_stop_on_restore = function()
         stop_called = true
       end,
-    }
+    })
 
     as.auto_restore_session_at_vim_enter()
 

--- a/tests/manually_named_autosave_spec.lua
+++ b/tests/manually_named_autosave_spec.lua
@@ -1,8 +1,8 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("Manually named sessions", function()
-  require("auto-session").setup { auto_create = false }
+  require("auto-session").setup({ auto_create = false })
 
   it("can autosave", function()
     TL.clearSessionFilesAndBuffers()
@@ -28,8 +28,8 @@ describe("Manually named sessions", function()
     -- This needs to be cleared to simulate the current session not being manually named
     -- Passing nothing to the SaveSession function will use the current manually named
     -- session if the flag is set
-    require("auto-session").manually_named_session = false 
-    require("auto-session").SaveSession() 
+    require("auto-session").manually_named_session = false
+    require("auto-session").SaveSession()
 
     vim.cmd("e " .. TL.other_file)
     assert.equals(1, vim.fn.bufexists(TL.other_file))
@@ -47,11 +47,11 @@ describe("Manually named sessions", function()
     TL.clearSessionFilesAndBuffers()
     local original_cwd = vim.fn.getcwd()
 
-    require("auto-session").setup {
+    require("auto-session").setup({
       single_session_mode = true,
       auto_create = false,
       -- log_level = "debug",
-    }
+    })
 
     vim.cmd("e " .. TL.test_file)
 

--- a/tests/mini-tests/test_ui.lua
+++ b/tests/mini-tests/test_ui.lua
@@ -3,7 +3,7 @@
 local new_set = MiniTest.new_set
 local expect, eq = MiniTest.expect, MiniTest.expect.equality
 
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 -- Factory function to generate tests with different configs
 local function make_tests(picker, autosession_config, other_config)
@@ -12,14 +12,14 @@ local function make_tests(picker, autosession_config, other_config)
 
   other_config = other_config or ""
 
-  local T = new_set {
+  local T = new_set({
     hooks = {
       pre_once = function()
         TL.clearSessionFilesAndBuffers()
       end,
       pre_case = function()
         -- Restart child process with custom 'init.lua' script
-        child.restart { "-u", "scripts/minimal_init_mini.lua", "-V9" }
+        child.restart({ "-u", "scripts/minimal_init_mini.lua", "-V9" })
         -- Load tested plugin with passed config
         child.lua(string.format(
           [[
@@ -32,7 +32,7 @@ local function make_tests(picker, autosession_config, other_config)
       end,
       post_once = child.stop,
     },
-  }
+  })
 
   ---manual timeout function that works with MiniTest
   ---@param timeout integer timeout in ms
@@ -53,12 +53,12 @@ local function make_tests(picker, autosession_config, other_config)
     return fun()
   end
 
-  T["session lens"] = new_set {}
+  T["session lens"] = new_set({})
 
   T["session lens"]["save a default session"] = function()
     child.cmd("e " .. TL.test_file)
     expect.equality(1, child.fn.bufexists(TL.test_file))
-    child.cmd "SessionSave"
+    child.cmd("SessionSave")
 
     expect.equality(1, child.fn.bufexists(TL.test_file))
     expect.equality(1, vim.fn.filereadable(TL.default_session_path))
@@ -70,20 +70,20 @@ local function make_tests(picker, autosession_config, other_config)
     child.cmd("SessionSave " .. TL.named_session_name)
     expect.equality(1, vim.fn.filereadable(TL.named_session_path))
 
-    child.cmd "%bw!"
+    child.cmd("%bw!")
 
     child.cmd("e " .. TL.other_file)
-    child.cmd "SessionSave project_x"
+    child.cmd("SessionSave project_x")
   end
 
   T["session lens"]["can load a session"] = function()
     expect.equality(0, child.fn.bufexists(TL.other_file))
-    child.cmd "SessionSearch"
+    child.cmd("SessionSearch")
     vim.loop.sleep(300)
-    child.type_keys "project_x"
+    child.type_keys("project_x")
     -- print(child.get_screenshot())
     vim.loop.sleep(300)
-    child.type_keys "<cr>"
+    child.type_keys("<cr>")
     sleep_wait(2000, function()
       return child.fn.bufexists(TL.other_file) == 1
     end, 100)
@@ -94,12 +94,12 @@ local function make_tests(picker, autosession_config, other_config)
   if picker == "select" then
     T["session lens"]["can delete a session"] = function()
       expect.equality(1, vim.fn.filereadable(TL.named_session_path))
-      child.cmd "Autosession delete"
+      child.cmd("Autosession delete")
       vim.loop.sleep(300)
-      child.type_keys "mysession"
+      child.type_keys("mysession")
       -- print(child.get_screenshot())
       vim.loop.sleep(300)
-      child.type_keys "<cr>"
+      child.type_keys("<cr>")
       sleep_wait(2000, function()
         return vim.fn.filereadable(TL.named_session_path) == 0
       end, 100)
@@ -108,12 +108,12 @@ local function make_tests(picker, autosession_config, other_config)
   else
     T["session lens"]["can copy a session"] = function()
       expect.equality(0, child.fn.bufexists(TL.test_file))
-      child.cmd "SessionSearch"
+      child.cmd("SessionSearch")
       local session_name = "project_x"
       vim.loop.sleep(300)
       child.type_keys(session_name)
       vim.loop.sleep(100)
-      child.type_keys "<C-Y>"
+      child.type_keys("<C-Y>")
       vim.loop.sleep(100)
       -- print(child.get_screenshot())
       local copy_name = "copy"
@@ -128,12 +128,12 @@ local function make_tests(picker, autosession_config, other_config)
 
     T["session lens"]["can delete a session"] = function()
       expect.equality(1, vim.fn.filereadable(TL.named_session_path))
-      child.cmd "SessionSearch"
+      child.cmd("SessionSearch")
       vim.loop.sleep(300)
-      child.type_keys "mysession"
+      child.type_keys("mysession")
       -- print(child.get_screenshot())
       vim.loop.sleep(300)
-      child.type_keys "<c-d>"
+      child.type_keys("<c-d>")
       sleep_wait(2000, function()
         return vim.fn.filereadable(TL.named_session_path) == 0
       end, 100)
@@ -144,7 +144,7 @@ local function make_tests(picker, autosession_config, other_config)
   return T
 end
 
-local combined = new_set {}
+local combined = new_set({})
 
 local pickers = {
   { "telescope", "require('telescope').setup()" },
@@ -155,7 +155,7 @@ local pickers = {
   { "select", "require('snacks').setup({picker = {enabled = true}})" },
 }
 
-if vim.fn.executable "fzf" == 1 then
+if vim.fn.executable("fzf") == 1 then
   table.insert(pickers, { "fzf", "require('fzf-lua').setup()" })
 end
 

--- a/tests/preserve_buffer_on_restore_spec.lua
+++ b/tests/preserve_buffer_on_restore_spec.lua
@@ -1,14 +1,14 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("preserve_buffer_on_restore", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
 
-  as.setup {
+  as.setup({
     preserve_buffer_on_restore = function(buf_nr)
       return string.find(vim.api.nvim_buf_get_name(buf_nr):gsub("\\", "/"), TL.other_file, 1, true) ~= nil
     end,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -19,7 +19,7 @@ describe("preserve_buffer_on_restore", function()
     assert.True(as.AutoSaveSession())
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
 
-    vim.cmd "silent %bw!"
+    vim.cmd("silent %bw!")
 
     -- open another buffer to test preserving
     vim.cmd("e " .. TL.other_file)

--- a/tests/purge_old_sessions_spec.lua
+++ b/tests/purge_old_sessions_spec.lua
@@ -1,22 +1,22 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
-local stub = require "luassert.stub"
+local TL = require("tests/test_lib")
+local stub = require("luassert.stub")
 
 describe("Setting purge_after_minutes", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
 
   -- old session 10 days ago
   local old_session = 10
 
-  as.setup {
+  as.setup({
     purge_after_minutes = 60 * 24 * 3,
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
   vim.cmd("e " .. TL.test_file)
 
   -- requires nvim >= 0.10
-  if vim.fn.has "nvim-0.10" == 1 then
+  if vim.fn.has("nvim-0.10") == 1 then
     it("does purge old sessions while leaving recent ones", function()
       as.SaveSession()
       as.SaveSession(TL.named_session_name)

--- a/tests/restore_error_handler_spec.lua
+++ b/tests/restore_error_handler_spec.lua
@@ -1,8 +1,8 @@
-require "plenary"
-local TL = require "tests/test_lib"
+require("plenary")
+local TL = require("tests/test_lib")
 
 describe("restore_error_handler", function()
-  local as = require "auto-session"
+  local as = require("auto-session")
   local should_return
   local was_called = false
 
@@ -22,12 +22,12 @@ describe("restore_error_handler", function()
     assert.False(as.RestoreSession())
   end)
 
-  as.setup {
+  as.setup({
     restore_error_handler = function()
       was_called = true
       return should_return
     end,
-  }
+  })
 
   it("can suppress errors", function()
     TL.clearSessionFilesAndBuffers()

--- a/tests/session_control_spec.lua
+++ b/tests/session_control_spec.lua
@@ -1,13 +1,13 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The default config", function()
-  local as = require "auto-session"
-  local Lib = require "auto-session.lib"
+  local as = require("auto-session")
+  local Lib = require("auto-session.lib")
 
-  as.setup {
+  as.setup({
     -- log_level = "debug",
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
@@ -15,15 +15,15 @@ describe("The default config", function()
     vim.cmd("e " .. TL.test_file)
 
     ---@diagnostic disable-next-line: missing-parameter
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
     -- Make sure the session was created
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
 
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
     -- Session control is only written on restore
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     -- Make sure the restore worked
     assert.equals(1, vim.fn.bufexists(TL.test_file))
@@ -36,7 +36,7 @@ describe("The default config", function()
     -- Save a new session
     vim.cmd("SessionSave " .. TL.named_session_name)
 
-    vim.cmd "%bw!"
+    vim.cmd("%bw!")
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
@@ -60,11 +60,11 @@ describe("The default config", function()
 
   it("Saving twice doesn't set alternate", function()
     -- Save a session then restore it twice to make sure it's not both current and alternate
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
-    vim.cmd "SessionRestore "
+    vim.cmd("SessionRestore ")
 
     -- Make sure the session control file was written
     assert.equals(1, vim.fn.filereadable(TL.default_session_control_path))
@@ -86,7 +86,7 @@ describe("The default config", function()
     assert.equals("table", type(session_control))
 
     -- Don't throw an error on not a js file
-    session_control = Lib.load_session_control_file "tests/session_control_spec.lua"
+    session_control = Lib.load_session_control_file("tests/session_control_spec.lua")
     assert.equals("table", type(session_control))
   end)
 end)

--- a/tests/session_dir_custom_spec.lua
+++ b/tests/session_dir_custom_spec.lua
@@ -1,5 +1,5 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 local custom_session_dir = "/tests/custom_sessions/"
 
@@ -7,19 +7,19 @@ TL.clearSessionFilesAndBuffers()
 TL.clearSessionFiles(custom_session_dir)
 
 describe("A custom session dir config", function()
-  local as = require "auto-session"
-  as.setup {
+  local as = require("auto-session")
+  as.setup({
     -- Remove trailing slash
     auto_session_root_dir = vim.fn.getcwd() .. custom_session_dir,
     -- log_level = "debug",
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
   vim.cmd("e " .. TL.test_file)
 
   it("can save default session to the directory", function()
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
@@ -39,12 +39,12 @@ describe("A custom session dir config", function()
   it("can load default session from the directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)
@@ -68,7 +68,7 @@ describe("A custom session dir config", function()
   it("can load a named session from the directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))

--- a/tests/session_dir_no_slash_spec.lua
+++ b/tests/session_dir_no_slash_spec.lua
@@ -1,18 +1,18 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("A session directory with no trailing slash", function()
-  require("auto-session").setup {
+  require("auto-session").setup({
     -- Remove trailing slash
     auto_session_root_dir = TL.session_dir:gsub("/$", ""),
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
 
   vim.cmd("e " .. TL.test_file)
 
   it("saves a session to the directory", function()
-    vim.cmd "SessionSave"
+    vim.cmd("SessionSave")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
@@ -23,12 +23,12 @@ describe("A session directory with no trailing slash", function()
   it("loads a session from the directory", function()
     assert.equals(1, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "silent %bw"
+    vim.cmd("silent %bw")
 
     -- Make sure the buffer is gone
     assert.equals(0, vim.fn.bufexists(TL.test_file))
 
-    vim.cmd "SessionRestore"
+    vim.cmd("SessionRestore")
 
     assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)

--- a/tests/single_session_mode_spec.lua
+++ b/tests/single_session_mode_spec.lua
@@ -1,18 +1,18 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("single_session_mode", function()
-  local as = require "auto-session"
-  local lib = require "auto-session.lib"
+  local as = require("auto-session")
+  local lib = require("auto-session.lib")
 
   TL.clearSessionFilesAndBuffers()
 
   it("uses a single session file when enabled", function()
     local original_cwd = vim.fn.getcwd(-1, -1)
 
-    as.setup {
+    as.setup({
       single_session_mode = true,
-    }
+    })
 
     -- Verify no session exists initially
     assert.equals(0, vim.fn.filereadable(TL.default_session_path))
@@ -26,7 +26,7 @@ describe("single_session_mode", function()
     TL.assertSessionHasFile(TL.default_session_path, "test.txt")
 
     -- Change directory to a subdirectory
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
     local new_cwd = vim.fn.getcwd(-1, -1)
     assert.True(new_cwd ~= original_cwd)
 
@@ -50,9 +50,9 @@ describe("single_session_mode", function()
   it("uses current cwd when disabled", function()
     local original_cwd = vim.fn.getcwd()
 
-    as.setup {
+    as.setup({
       single_session_mode = false,
-    }
+    })
 
     -- ensure manually_named_session isn't set
     as.manually_named_session = nil
@@ -69,7 +69,7 @@ describe("single_session_mode", function()
     TL.assertSessionHasFile(TL.default_session_path, "test.txt")
 
     -- Change directory to a subdirectory
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
     local new_cwd = vim.fn.getcwd()
     assert.True(new_cwd ~= original_cwd)
 
@@ -96,9 +96,9 @@ describe("single_session_mode", function()
   it("properly clears manually_named_session when disabled", function()
     local original_cwd = vim.fn.getcwd()
 
-    as.setup {
+    as.setup({
       single_session_mode = false,
-    }
+    })
 
     -- Start with manually_named_session cleared
     as.manually_named_session = nil
@@ -129,19 +129,19 @@ describe("single_session_mode", function()
   end)
 
   it("maintains single session mode functionality when restoring sessions ", function()
-    as.setup {
+    as.setup({
       single_session_mode = false,
-    }
+    })
     as.manually_named_session = nil
 
     local original_cwd = vim.fn.getcwd()
 
     -- Change to tests directory and create a session there
-    vim.cmd "cd tests"
+    vim.cmd("cd tests")
     local tests_cwd = vim.fn.getcwd()
 
     -- Create a test file and save session
-    vim.cmd "e test.txt"
+    vim.cmd("e test.txt")
     as.SaveSession()
 
     -- Verify the session was created
@@ -150,7 +150,7 @@ describe("single_session_mode", function()
 
     -- Go back to original directory and create another session
     vim.cmd("cd " .. original_cwd)
-    vim.cmd "e test.txt"
+    vim.cmd("e test.txt")
     as.SaveSession()
 
     -- Verify the session was created
@@ -158,9 +158,9 @@ describe("single_session_mode", function()
     assert.equals(1, vim.fn.filereadable(original_session_path))
 
     -- Now enable single_session_mode and setup again
-    as.setup {
+    as.setup({
       single_session_mode = true,
-    }
+    })
 
     -- Verify vim.v.this_session is set to original directory session
     local original_session_path = TL.session_dir .. lib.escape_session_name(original_cwd) .. ".vim"
@@ -185,24 +185,24 @@ describe("single_session_mode", function()
 
     local original_cwd = vim.fn.getcwd(-1, -1)
 
-    as.setup {
+    as.setup({
       single_session_mode = true,
-    }
+    })
 
     -- Create a manually named session
     vim.cmd("e " .. TL.test_file)
-    as.SaveSession "my_project"
+    as.SaveSession("my_project")
 
     -- Verify the named session was created
-    local named_session_path = TL.session_dir .. lib.escape_session_name "my_project" .. ".vim"
+    local named_session_path = TL.session_dir .. lib.escape_session_name("my_project") .. ".vim"
     assert.equals(1, vim.fn.filereadable(named_session_path))
 
     -- Verify vim.v.this_session is set to the manually named session
     assert.equals(named_session_path, vim.v.this_session)
 
     -- Change directory and save again - should still save to the named session
-    vim.cmd "cd tests"
-    vim.cmd "e test2.txt"
+    vim.cmd("cd tests")
+    vim.cmd("e test2.txt")
     as.SaveSession()
 
     -- Should still save to the named session
@@ -222,13 +222,13 @@ describe("single_session_mode", function()
   it("gets disabled automatically when cwd_change_handling is also enabled", function()
     TL.clearSessionFilesAndBuffers()
     as.manually_named_session = nil -- Reset manually_named_session
-    as.setup {
+    as.setup({
       single_session_mode = true,
       cwd_change_handling = true, -- Note, this test is last in this file because this config conflict will bleed into other tests
-    }
+    })
 
     -- The config validation should have disabled single_session_mode
-    local config = require "auto-session.config"
+    local config = require("auto-session.config")
     assert.False(config.single_session_mode)
     assert.True(config.cwd_change_handling)
 
@@ -238,4 +238,3 @@ describe("single_session_mode", function()
 
   TL.clearSessionFilesAndBuffers()
 end)
-

--- a/tests/suppress_dirs_spec.lua
+++ b/tests/suppress_dirs_spec.lua
@@ -1,14 +1,14 @@
 ---@diagnostic disable: undefined-field
-local TL = require "tests/test_lib"
+local TL = require("tests/test_lib")
 
 describe("The suppress dirs config", function()
-  local as = require "auto-session"
-  local c = require "auto-session.config"
+  local as = require("auto-session")
+  local c = require("auto-session.config")
 
-  as.setup {
+  as.setup({
     auto_session_root_dir = TL.session_dir,
     auto_session_suppress_dirs = { vim.fn.getcwd() },
-  }
+  })
 
   TL.clearSessionFilesAndBuffers()
   vim.cmd("e " .. TL.test_file)
@@ -22,10 +22,10 @@ describe("The suppress dirs config", function()
   end)
 
   it("saves a session for a non-suppressed dir", function()
-    as.setup {
+    as.setup({
       auto_session_root_dir = TL.session_dir,
       auto_session_suppress_dirs = { "/dummy" },
-    }
+    })
     ---@diagnostic disable-next-line: missing-parameter
     as.AutoSaveSession()
 
@@ -42,7 +42,7 @@ describe("The suppress dirs config", function()
     c.suppressed_dirs = { vim.fn.getcwd() .. "/tests/*" }
 
     -- Change to a sub directory to see if it's allowed
-    vim.cmd "cd tests/test_files"
+    vim.cmd("cd tests/test_files")
 
     local session_path = TL.makeSessionPath(vim.fn.getcwd())
     assert.equals(0, vim.fn.filereadable(session_path))
@@ -57,11 +57,11 @@ describe("The suppress dirs config", function()
 
   it("doesn't save a session for a suppressed dir even if also an allowed dir", function()
     vim.cmd("e " .. TL.test_file)
-    as.setup {
+    as.setup({
       auto_session_root_dir = TL.session_dir,
       auto_session_suppress_dirs = { vim.fn.getcwd() },
       auto_session_allowed_dirs = { vim.fn.getcwd() },
-    }
+    })
     ---@diagnostic disable-next-line: missing-parameter
     as.AutoSaveSession()
 

--- a/tests/test_lib.lua
+++ b/tests/test_lib.lua
@@ -1,4 +1,4 @@
-local asLib = require "auto-session.lib"
+local asLib = require("auto-session.lib")
 local M = {}
 
 -- This disables the headless check inside autosession
@@ -11,7 +11,7 @@ function M.escapeSessionName(session_name)
 end
 
 function M.legacyEscapeSessionName(session_name)
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     -- Hardcoded implementation from Lib
     local temp = session_name:gsub(":", "++")
     if not vim.o.shellslash then
@@ -33,9 +33,9 @@ M.test_file = M.tests_base_dir .. "/test_files/test.txt"
 M.other_file = M.tests_base_dir .. "/test_files/other.txt"
 
 -- This is set in minimal.lua to be auto-session/.test/...
-M.session_dir = vim.fn.expand(vim.fn.stdpath "data" .. "/sessions/")
+M.session_dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/")
 
-M.session_control_dir = vim.fn.stdpath "data" .. "/auto_session/"
+M.session_control_dir = vim.fn.stdpath("data") .. "/auto_session/"
 
 -- Construct the session name for the current directory
 M.default_session_name = vim.fn.getcwd()
@@ -50,7 +50,7 @@ M.named_session_name = "mysession"
 M.named_session_path = M.session_dir .. M.named_session_name .. ".vim"
 
 function M.fileHasString(file_path, string)
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     -- Have to make sure it's windows' native find (and not MinGW's find), so we use specify SystemRoot
     -- This is necessary to make it work for the GH action
     return vim.fn
@@ -61,7 +61,7 @@ function M.fileHasString(file_path, string)
 end
 
 function M.sessionHasFile(session_path, file)
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     -- Have to make sure it's windows' native find (and not MinGW's find), so we use specify SystemRoot
     -- This is necessary to make it work for the GH action
     return vim.fn
@@ -92,12 +92,12 @@ end
 function M.clearSessionFilesAndBuffers()
   M.clearSessionFiles(M.session_dir)
   M.clearSessionFiles(M.session_control_dir)
-  vim.cmd "silent %bw"
+  vim.cmd("silent %bw")
 end
 
 ---Cross platform delete all files in directory
 function M.clearSessionFiles(dir)
-  if vim.fn.has "win32" == 1 then
+  if vim.fn.has("win32") == 1 then
     pcall(vim.fn.system, "del /Q " .. (dir .. "*.vim .vim"):gsub("/", "\\"))
   else
     pcall(vim.fn.system, "rm -rf " .. dir .. "*.vim .vim")


### PR DESCRIPTION
No functional changes, just removing `no_call_parentheses` as [discussed](https://github.com/rmagatti/auto-session/issues/186#issuecomment-3193761691).