### PR TITLE
fix: better file tree compatibility

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -8,6 +8,9 @@ local uv = vim.uv or vim.loop
 ---@mod auto-session.api API
 local AutoSession = {}
 
+---Tracks the arguments nvim was launched with. Will be set to nil if a session is restored
+local launch_argv = nil
+
 ---Setup function for AutoSession
 ---@param config AutoSession.Config|nil Config for auto session
 function AutoSession.setup(config)
@@ -26,6 +29,10 @@ function AutoSession.setup(config)
   end
 
   require("auto-session.autocmds").setup_autocmds()
+
+  -- save argv
+  launch_argv = vim.fn.argv()
+  Lib.logger.debug("Saving argv at setup: " .. vim.inspect(launch_argv))
 end
 
 ---Determines the session name based on current state and parameters
@@ -71,9 +78,6 @@ end
 local in_pager_mode = function()
   return vim.g.in_pager_mode == Lib._VIM_TRUE
 end
-
----Tracks the arguments nvim was launched with. Will be set to nil if a session is restored
-local launch_argv = nil
 
 ---Returns whether Auto restoring / saving is enabled for the args nvim was launched with
 ---@param is_save boolean Is this being called during saving or restoring
@@ -519,14 +523,14 @@ end
 ---Also make sure to call no_restore if no session was restored
 ---@return boolean # Was a session restored
 function AutoSession.auto_restore_session_at_vim_enter()
-  -- Save the launch args here as restoring a session will replace vim.fn.argv. We clear
-  -- launch_argv in restore session so it's only used for the session launched from the command
-  -- line
-  launch_argv = vim.fn.argv()
+  -- launch_argv is captured during setup as that happens before `VimEnter` which
+  -- is important because some plugins (.e.g. NvimTree) rewrite the arguments before
+  -- we get to see them
 
   -- Is there exactly one argument and is it a directory?
   if
     Config.args_allow_single_directory
+    and launch_argv
     and #launch_argv == 1
     and vim.fn.isdirectory(launch_argv[1]) == Lib._VIM_TRUE
   then

--- a/tests/args_files_enabled_spec.lua
+++ b/tests/args_files_enabled_spec.lua
@@ -4,7 +4,10 @@ local stub = require("luassert.stub")
 
 describe("The args files enabled config", function()
   local no_restore_hook_called = false
-  require("auto-session").setup({
+  local as = require("auto-session")
+  local c = require("auto-session.config")
+
+  as.setup({
     args_allow_single_directory = false,
     args_allow_files_auto_save = true,
 
@@ -43,6 +46,9 @@ describe("The args files enabled config", function()
     local s = stub(vim.fn, "argv")
     s.returns({ "." })
 
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
+
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())
 
@@ -60,6 +66,9 @@ describe("The args files enabled config", function()
 
     local s = stub(vim.fn, "argv")
     s.returns({ TL.other_file })
+
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())

--- a/tests/args_not_enabled_spec.lua
+++ b/tests/args_not_enabled_spec.lua
@@ -4,7 +4,10 @@ local stub = require("luassert.stub")
 
 describe("The args not enabled config", function()
   local no_restore_hook_called = false
-  require("auto-session").setup({
+  local as = require("auto-session")
+  local c = require("auto-session.config")
+
+  as.setup({
     args_allow_single_directory = false,
     args_allow_files_auto_save = false,
 
@@ -40,6 +43,9 @@ describe("The args not enabled config", function()
     local s = stub(vim.fn, "argv")
     s.returns({ "." })
 
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
+
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())
 
@@ -57,6 +63,9 @@ describe("The args not enabled config", function()
 
     local s = stub(vim.fn, "argv")
     s.returns({ TL.test_file })
+
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())

--- a/tests/args_single_dir_enabled_spec.lua
+++ b/tests/args_single_dir_enabled_spec.lua
@@ -45,6 +45,9 @@ describe("The args single dir enabled config", function()
     local s = stub(vim.fn, "argv")
     s.returns({ "tests" })
 
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
+
     -- only exported because we set the unit testing env in TL
     assert.False(as.auto_restore_session_at_vim_enter())
     assert.equals(true, no_restore_hook_called)
@@ -69,6 +72,9 @@ describe("The args single dir enabled config", function()
     local s = stub(vim.fn, "argv")
     s.returns({ cwd })
 
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
+
     -- only exported because we set the unit testing env in TL
     assert.equals(true, as.auto_restore_session_at_vim_enter())
 
@@ -87,6 +93,9 @@ describe("The args single dir enabled config", function()
 
     local s = stub(vim.fn, "argv")
     s.returns({ TL.test_file })
+
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
 
     -- only exported because we set the unit testing env in TL
     assert.equals(false, as.auto_restore_session_at_vim_enter())

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -149,13 +149,16 @@ describe("The git config", function()
 
   it("load a session named with git branch from . directory", function()
     c.args_allow_single_directory = true
-    c.log_level = "debug"
+    -- c.log_level = "debug"
 
     -- delete all buffers
     vim.cmd("silent %bw")
 
     local s = stub(vim.fn, "argv")
     s.returns({ "." })
+
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
 
     -- only exported because we set the unit testing env in TL
     assert.True(as.auto_restore_session_at_vim_enter())
@@ -181,6 +184,9 @@ describe("The git config", function()
 
     local s = stub(vim.fn, "argv")
     s.returns({ git_test_dir })
+
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
 
     -- only exported because we set the unit testing env in TL
     assert.True(as.auto_restore_session_at_vim_enter())


### PR DESCRIPTION
Grab `vim.fn.argv()` during setup instead of waiting until VimEnter so we capture the value before file tree plugins (e.g. NvimTree) have a chance to change it. This is more robust that the trying to make sure the file tree plugin is loaded lazily after auto-session.

Fixes #488