### PR TITLE
feat(hooks)!: pre_save/restore can stop auto save/restore 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,16 @@ local defaults = {
 ---@field control_filename? string
 ---
 ---Hooks
----@field pre_save_cmds? table executes before a session is saved
----@field save_extra_cmds? table executes before a session is saved
+---@field pre_save_cmds? (string|fun(session_name:string))[] executes before a session is saved, return false to stop auto-saving
 ---@field post_save_cmds? table executes after a session is saved
----@field pre_restore_cmds? table executes before a session is restored
+---@field pre_restore_cmds? (string|fun(session_name:string))[] executes before a session is restored, return false to stop auto-restoring
 ---@field post_restore_cmds? table executes after a session is restored
 ---@field pre_delete_cmds? table executes before a session is deleted
 ---@field post_delete_cmds? table executes after a session is deleted
 ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
 ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
 ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
+---@field save_extra_cmds? table executes before a session is saved
 ```
 
 <!-- types:end -->

--- a/README.md
+++ b/README.md
@@ -462,18 +462,18 @@ require("lualine").setup({
 
 Command hooks exist in the format: {hook_name}
 
-- `{pre_save}`: executes _before_ a session is saved
-- `{save_extra}`: executes _after_ a session is saved, saves returned string or table to `*x.vim`, reference `:help mks`
+- `{pre_save}`: executes _before_ a session is saved, return false to stop auto-save
 - `{post_save}`: executes _after_ a session is saved
-- `{pre_restore}`: executes _before_ a session is restored
+- `{pre_restore}`: executes _before_ a session is restored, return false to stop auto-restore
 - `{post_restore}`: executes _after_ a session is restored
 - `{pre_delete}`: executes _before_ a session is deleted
 - `{post_delete}`: executes _after_ a session is deleted
-- `{no_restore}`: executes when no session is auto-restored, happens _after_ `VimEnter` (and possibly on cwd/git branch change)
+- `{no_restore}`: executes when no session is auto-restored, happens _after_ `VimEnter` (and possibly on cwd/git branch change, if enabled)
 - `{pre_cwd_changed}`: executes _before_ a directory is changed (if `cwd_change_handling` is enabled)
 - `{post_cwd_changed}`: executes _after_ a directory is changed (if `cwd_change_handling` is enabled)
+- `{save_extra}`: executes _after_ a session is saved, saves returned string or table to `*x.vim`, reference `:help mks`
 
-Each hook is a table of vim commands or lua functions (or a mix of both):
+Each hook is a table of vim commands or lua functions (or a mix of both). Here are some examples of what you can do:
 
 ```lua
 opts = {
@@ -481,6 +481,19 @@ opts = {
 
   pre_save_cmds = {
     "tabdo NERDTreeClose", -- Close NERDTree before saving session
+    function(session_name)
+      if some_test() then -- don't auto-save if some_test() is true
+        return false
+      end
+    end,
+  },
+
+  pre_restore_cmds = {
+    function(session_name)
+      if some_test() then -- don't auto-restore if some_test() is true
+        return false
+      end
+    end,
   },
 
   post_restore_cmds = {

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ local defaults = {
 ---@field control_filename? string
 ---
 ---Hooks
----@field pre_save_cmds? (string|fun(session_name:string))[] executes before a session is saved, return false to stop auto-saving
----@field post_save_cmds? table executes after a session is saved
----@field pre_restore_cmds? (string|fun(session_name:string))[] executes before a session is restored, return false to stop auto-restoring
----@field post_restore_cmds? table executes after a session is restored
----@field pre_delete_cmds? table executes before a session is deleted
----@field post_delete_cmds? table executes after a session is deleted
+---@field pre_save_cmds? (string|fun(session_name:string): allow_save:boolean)[] executes before a session is saved, return false to stop auto-saving
+---@field post_save_cmds? (string|fun(session_name:string))[] executes after a session is saved
+---@field pre_restore_cmds? (string|fun(session_name:string): allow_restore:boolean)[] executes before a session is restored, return false to stop auto-restoring
+---@field post_restore_cmds? (string|fun(session_name:string))[] executes after a session is restored
+---@field pre_delete_cmds? (string|fun(session_name:string))[] executes before a session is deleted
+---@field post_delete_cmds? (string|fun(session_name:string))[] executes after a session is deleted
 ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
 ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
 ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -213,12 +213,12 @@ Types ~
     ---@field control_filename? string
     ---
     ---Hooks
-    ---@field pre_save_cmds? (string|fun(session_name:string))[] executes before a session is saved, return false to stop auto-saving
-    ---@field post_save_cmds? table executes after a session is saved
-    ---@field pre_restore_cmds? (string|fun(session_name:string))[] executes before a session is restored, return false to stop auto-restoring
-    ---@field post_restore_cmds? table executes after a session is restored
-    ---@field pre_delete_cmds? table executes before a session is deleted
-    ---@field post_delete_cmds? table executes after a session is deleted
+    ---@field pre_save_cmds? (string|fun(session_name:string): allow_save:boolean)[] executes before a session is saved, return false to stop auto-saving
+    ---@field post_save_cmds? (string|fun(session_name:string))[] executes after a session is saved
+    ---@field pre_restore_cmds? (string|fun(session_name:string): allow_restore:boolean)[] executes before a session is restored, return false to stop auto-restoring
+    ---@field post_restore_cmds? (string|fun(session_name:string))[] executes after a session is restored
+    ---@field pre_delete_cmds? (string|fun(session_name:string))[] executes before a session is deleted
+    ---@field post_delete_cmds? (string|fun(session_name:string))[] executes after a session is deleted
     ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
     ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
     ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,4 @@
-*auto-session.txt*           For Neovim           Last change: 2025 October 02
+*auto-session.txt*           For Neovim           Last change: 2025 October 03
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -213,16 +213,16 @@ Types ~
     ---@field control_filename? string
     ---
     ---Hooks
-    ---@field pre_save_cmds? table executes before a session is saved
-    ---@field save_extra_cmds? table executes before a session is saved
+    ---@field pre_save_cmds? (string|fun(session_name:string))[] executes before a session is saved, return false to stop auto-saving
     ---@field post_save_cmds? table executes after a session is saved
-    ---@field pre_restore_cmds? table executes before a session is restored
+    ---@field pre_restore_cmds? (string|fun(session_name:string))[] executes before a session is restored, return false to stop auto-restoring
     ---@field post_restore_cmds? table executes after a session is restored
     ---@field pre_delete_cmds? table executes before a session is deleted
     ---@field post_delete_cmds? table executes after a session is deleted
     ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
     ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
     ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
+    ---@field save_extra_cmds? table executes before a session is saved
 <
 
 
@@ -533,18 +533,19 @@ COMMAND HOOKS ARE A LIST OF COMMANDS OR FUNCTIONS THAT GET EXECUTED AT DIFFERENT
 
 Command hooks exist in the format: {hook_name}
 
-- `{pre_save}`: executes _before_ a session is saved
-- `{save_extra}`: executes _after_ a session is saved, saves returned string or table to `*x.vim`, reference `:help mks`
+- `{pre_save}`: executes _before_ a session is saved, return false to stop auto-save
 - `{post_save}`: executes _after_ a session is saved
-- `{pre_restore}`: executes _before_ a session is restored
+- `{pre_restore}`: executes _before_ a session is restored, return false to stop auto-restore
 - `{post_restore}`: executes _after_ a session is restored
 - `{pre_delete}`: executes _before_ a session is deleted
 - `{post_delete}`: executes _after_ a session is deleted
-- `{no_restore}`: executes when no session is auto-restored, happens _after_ `VimEnter` (and possibly on cwd/git branch change)
+- `{no_restore}`: executes when no session is auto-restored, happens _after_ `VimEnter` (and possibly on cwd/git branch change, if enabled)
 - `{pre_cwd_changed}`: executes _before_ a directory is changed (if `cwd_change_handling` is enabled)
 - `{post_cwd_changed}`: executes _after_ a directory is changed (if `cwd_change_handling` is enabled)
+- `{save_extra}`: executes _after_ a session is saved, saves returned string or table to `*x.vim`, reference `:help mks`
 
-Each hook is a table of vim commands or lua functions (or a mix of both):
+Each hook is a table of vim commands or lua functions (or a mix of both). Here
+are some examples of what you can do:
 
 >lua
     opts = {
@@ -552,6 +553,19 @@ Each hook is a table of vim commands or lua functions (or a mix of both):
     
       pre_save_cmds = {
         "tabdo NERDTreeClose", -- Close NERDTree before saving session
+        function(session_name)
+          if some_test() then -- don't auto-save if some_test() is true
+            return false
+          end
+        end,
+      },
+    
+      pre_restore_cmds = {
+        function(session_name)
+          if some_test() then -- don't auto-restore if some_test() is true
+            return false
+          end
+        end,
       },
     
       post_restore_cmds = {

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -72,16 +72,16 @@ local M = {}
 ---@field control_filename? string
 ---
 ---Hooks
----@field pre_save_cmds? table executes before a session is saved
----@field save_extra_cmds? table executes before a session is saved
+---@field pre_save_cmds? (string|fun(session_name:string))[] executes before a session is saved, return false to stop auto-saving
 ---@field post_save_cmds? table executes after a session is saved
----@field pre_restore_cmds? table executes before a session is restored
+---@field pre_restore_cmds? (string|fun(session_name:string))[] executes before a session is restored, return false to stop auto-restoring
 ---@field post_restore_cmds? table executes after a session is restored
 ---@field pre_delete_cmds? table executes before a session is deleted
 ---@field post_delete_cmds? table executes after a session is deleted
 ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
 ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
 ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
+---@field save_extra_cmds? table executes before a session is saved
 
 ---@type AutoSession.Config
 local defaults = {

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -72,12 +72,12 @@ local M = {}
 ---@field control_filename? string
 ---
 ---Hooks
----@field pre_save_cmds? (string|fun(session_name:string))[] executes before a session is saved, return false to stop auto-saving
----@field post_save_cmds? table executes after a session is saved
----@field pre_restore_cmds? (string|fun(session_name:string))[] executes before a session is restored, return false to stop auto-restoring
----@field post_restore_cmds? table executes after a session is restored
----@field pre_delete_cmds? table executes before a session is deleted
----@field post_delete_cmds? table executes after a session is deleted
+---@field pre_save_cmds? (string|fun(session_name:string): allow_save:boolean)[] executes before a session is saved, return false to stop auto-saving
+---@field post_save_cmds? (string|fun(session_name:string))[] executes after a session is saved
+---@field pre_restore_cmds? (string|fun(session_name:string): allow_restore:boolean)[] executes before a session is restored, return false to stop auto-restoring
+---@field post_restore_cmds? (string|fun(session_name:string))[] executes after a session is restored
+---@field pre_delete_cmds? (string|fun(session_name:string))[] executes before a session is deleted
+---@field post_delete_cmds? (string|fun(session_name:string))[] executes after a session is deleted
 ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
 ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
 ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -664,7 +664,7 @@ function AutoSession.save_session(session_name, opts)
 
   save_extra_cmds(session_path, session_name)
 
-  AutoSession.run_cmds("post_save")
+  AutoSession.run_cmds("post_save", session_name)
 
   -- session_name might be nil (e.g. when using cwd), unescape escaped_session_name instead
   Lib.logger.debug("Saved session: " .. Lib.unescape_session_name(escaped_session_name))
@@ -878,7 +878,7 @@ function AutoSession.restore_session_file(session_path, opts)
     require("auto-session.git").start_watcher(vim.fn.getcwd(-1, -1), ".git/HEAD")
   end
 
-  AutoSession.run_cmds("post_restore")
+  AutoSession.run_cmds("post_restore", session_name)
 
   write_to_session_control_json(session_path)
   return true
@@ -925,7 +925,7 @@ end
 ---@param session_name string Session name being deleted, just use to display messages
 ---@return boolean # Was the session file deleted
 function AutoSession.delete_session_file(session_path, session_name)
-  AutoSession.run_cmds("pre_delete")
+  AutoSession.run_cmds("pre_delete", session_name)
 
   Lib.logger.debug("delete_session_file deleting: " .. session_path)
 
@@ -953,7 +953,7 @@ function AutoSession.delete_session_file(session_path, session_name)
     Lib.logger.debug("delete_session_file deleting extra user commands: " .. extra_commands_path)
   end
 
-  AutoSession.run_cmds("post_delete")
+  AutoSession.run_cmds("post_delete", session_name)
   return result
 end
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -15,7 +15,6 @@ local launch_argv = nil
 ---@param config AutoSession.Config|nil Config for auto session
 function AutoSession.setup(config)
   Config.setup(config)
-  Lib.setup(Config.log_level)
   Lib.logger.debug("Config at start of setup", tostring(Config))
   Config.check(Lib.logger)
 

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -327,7 +327,7 @@ function AutoSession.auto_save_session()
   end
 
   -- Don't try to show a message as we're exiting
-  return AutoSession.save_session(current_session, false)
+  return AutoSession.save_session(current_session, { show_message = false, is_autosave = true })
 end
 
 ---@private
@@ -482,22 +482,22 @@ end
 ---@return boolean boolean returns whether restoring the session was successful or not.
 function AutoSession.auto_restore_session(session_name, is_startup)
   -- WARN: should this be checking is_allowed_dir as well?
-  if not is_enabled() or not auto_restore() or suppress_session(session_name) then
-    if not is_startup then
-      AutoSession.run_cmds("no_restore", false)
+  if is_enabled() and auto_restore() and not suppress_session(session_name) then
+    local opts = {
+      show_message = Config.show_auto_restore_notif,
+      is_autorestore = true,
+      is_startup_autorestore = is_startup,
+    }
+    if AutoSession.restore_session(session_name, opts) then
+      return true
     end
-    return false
   end
 
-  local opts = {
-    show_message = Config.show_auto_restore_notif,
-    is_startup_autorestore = is_startup,
-  }
-  local ret = AutoSession.restore_session(session_name, opts)
-  if not ret and not is_startup then
+  -- Because of the last session feature, startup calls no_restore hooks itself
+  if not is_startup then
     AutoSession.run_cmds("no_restore", false)
   end
-  return ret
+  return false
 end
 
 ---@private
@@ -574,16 +574,10 @@ function AutoSession.auto_restore_session_at_vim_enter()
     -- Check to see if the last session feature is on
     if Config.auto_restore_last_session then
       Lib.logger.debug("Last session is enabled, checking for session")
-
       local last_session_name = Lib.get_latest_session(AutoSession.get_root_dir())
       if last_session_name then
         Lib.logger.debug("Found last session: " .. last_session_name)
-        if
-          AutoSession.restore_session(
-            last_session_name,
-            { show_message = Config.show_auto_restore_notif, is_startup_autorestore = true }
-          )
-        then
+        if AutoSession.auto_restore_session(last_session_name, true) then
           return true
         end
       end
@@ -598,14 +592,19 @@ function AutoSession.auto_restore_session_at_vim_enter()
   return false
 end
 
+---@class SaveOpts
+---@field show_message boolean|nil Should messages be shown
+---@field is_autosave boolean|nil True if this is part of an auto-save
+
 ---Saves a session to the dir specified in the config. If no optional
 ---session name is passed in, it uses the cwd as the session name
 ---@param session_name? string|nil Optional session name
----@param show_message? boolean Optional, whether to show a message on save (true by default)
+---@param opts? SaveOpts save options
 ---@return boolean
-function AutoSession.save_session(session_name, show_message)
+function AutoSession.save_session(session_name, opts)
+  opts = opts or {}
   local session_dir = AutoSession.get_root_dir()
-  Lib.logger.debug("save_session start", { session_dir, session_name, show_message })
+  Lib.logger.debug("save_session start", { session_dir, session_name, opts })
 
   -- Canonicalize and create session_dir if needed
   session_dir = Lib.validate_root_dir(session_dir)
@@ -637,7 +636,18 @@ function AutoSession.save_session(session_name, show_message)
 
   Lib.close_ignored_filetypes(Config.close_filetypes_on_save)
 
-  AutoSession.run_cmds("pre_save")
+  local results = AutoSession.run_cmds("pre_save", session_name) or {}
+
+  if opts.is_autosave then
+    Lib.logger.debug("pre_save results:", results)
+    for _, result in ipairs(results) do
+      if result == false then
+        Lib.logger.debug("pre_save hook returned false, will not auto-save", results)
+        vim.notify("Not auto-saving session because a pre_save hook returned false")
+        return false
+      end
+    end
+  end
 
   -- We don't want to save arguments to the session as that can cause issues
   -- with buffers that can't be removed from the session as they keep being
@@ -658,7 +668,7 @@ function AutoSession.save_session(session_name, show_message)
 
   -- session_name might be nil (e.g. when using cwd), unescape escaped_session_name instead
   Lib.logger.debug("Saved session: " .. Lib.unescape_session_name(escaped_session_name))
-  if show_message == nil or show_message then
+  if opts.show_message == nil or opts.show_message then
     vim.notify("Saved session: " .. Lib.get_session_display_name(escaped_session_name))
   end
 
@@ -667,7 +677,8 @@ end
 
 ---@class RestoreOpts
 ---@field show_message boolean|nil Should messages be shown
----@field is_startup_autorestore boolean|nil True if this is the the startup autorestore
+---@field is_autorestore boolean|nil True if this is part of an auto-restore (startup, cwd, git)
+---@field is_startup_autorestore boolean|nil True if this is specifically a startup auto-restore
 
 ---Restores a session from the passed in directory. If no optional session name
 ---is passed in, it uses the cwd as the session name
@@ -772,7 +783,21 @@ function AutoSession.restore_session_file(session_path, opts)
   Lib.logger.debug("restore_session_file restoring session from: " .. session_path)
   opts = opts or {}
 
-  AutoSession.run_cmds("pre_restore")
+  local session_name = Lib.get_session_display_name(vim.fn.fnamemodify(session_path, ":t"))
+  local results = AutoSession.run_cmds("pre_restore", session_name) or {}
+
+  -- If this is an auto-restore and a pre_restore hook returned false
+  -- then abort restoring the session
+  if opts.is_autorestore then
+    Lib.logger.debug("pre_restore results:", results)
+    for _, result in ipairs(results) do
+      if result == false then
+        Lib.logger.debug("pre_restore hook returned false, will not auto-restore", results)
+        vim.notify("Not auto-restoring session because a pre_restore hook returned false")
+        return false
+      end
+    end
+  end
 
   -- Stop any language servers if config is set but don't do
   -- this on startup as it causes a perceptible delay (and we
@@ -843,7 +868,6 @@ function AutoSession.restore_session_file(session_path, opts)
     end
   end
 
-  local session_name = Lib.get_session_display_name(vim.fn.fnamemodify(session_path, ":t"))
   Lib.logger.debug("Restored session: " .. session_name)
   if opts.show_message == nil or opts.show_message then
     vim.notify("Restored session: " .. session_name)
@@ -961,7 +985,7 @@ end
 
 function AutoSession.SaveSession(session_name, show_message)
   vim.notify("SaveSession() is deprecated, use save_session()")
-  return AutoSession.save_session(session_name, show_message)
+  return AutoSession.save_session(session_name, { show_message = show_message })
 end
 
 function AutoSession.RestoreSession(session_name, opts)

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -1,16 +1,10 @@
 local Logger = require("auto-session.logger")
 
 local Lib = {
-  logger = {},
+  logger = Logger:new(),
   _VIM_FALSE = 0,
   _VIM_TRUE = 1,
 }
-
-function Lib.setup(log_level)
-  Lib.logger = Logger:new({
-    log_level = log_level,
-  })
-end
 
 local uv = vim.uv or vim.loop
 

--- a/lua/auto-session/logger.lua
+++ b/lua/auto-session/logger.lua
@@ -1,3 +1,5 @@
+local Config = require("auto-session.config")
+
 local Logger = {}
 
 ---Function that handles vararg printing, so logs are consistent.
@@ -34,7 +36,7 @@ function Logger:new(obj_and_config)
 end
 
 function Logger:debug(...)
-  if self.log_level == "debug" or self.log_level == vim.log.levels.DEBUG then
+  if Config.log_level == "debug" or Config.log_level == vim.log.levels.DEBUG then
     vim.notify("auto-session DEBUG: " .. to_print(...), vim.log.levels.DEBUG)
   end
 end
@@ -42,7 +44,7 @@ end
 function Logger:info(...)
   local valid_values = { "info", "debug", vim.log.levels.DEBUG, vim.log.levels.INFO }
 
-  if vim.tbl_contains(valid_values, self.log_level) then
+  if vim.tbl_contains(valid_values, Config.log_level) then
     vim.notify("auto-session INFO: " .. to_print(...), vim.log.levels.INFO)
   end
 end
@@ -50,7 +52,7 @@ end
 function Logger:warn(...)
   local valid_values = { "info", "debug", "warn", vim.log.levels.DEBUG, vim.log.levels.INFO, vim.log.levels.WARN }
 
-  if vim.tbl_contains(valid_values, self.log_level) then
+  if vim.tbl_contains(valid_values, Config.log_level) then
     vim.notify("auto-session WARN: " .. to_print(...), vim.log.levels.WARN)
   end
 end

--- a/tests/hooks_spec.lua
+++ b/tests/hooks_spec.lua
@@ -7,11 +7,15 @@ describe("Hooks", function()
   local pre_save_cmd_called = false
   local pre_save_session_name
   local post_save_cmd_called = false
+  local post_save_session_name
   local pre_restore_cmd_called = false
   local pre_restore_session_name
   local post_restore_cmd_called = false
+  local post_restore_session_name
   local pre_delete_cmd_called = false
+  local pre_delete_session_name
   local post_delete_cmd_called = false
+  local post_delete_session_name
 
   as.setup({
     pre_save_cmds = {
@@ -22,9 +26,10 @@ describe("Hooks", function()
       end,
     },
     post_save_cmds = {
-      function()
+      function(session_name)
         -- print("post_save_cmd")
         post_save_cmd_called = true
+        post_save_session_name = session_name
       end,
     },
     pre_restore_cmds = {
@@ -34,18 +39,21 @@ describe("Hooks", function()
       end,
     },
     post_restore_cmds = {
-      function()
+      function(session_name)
         post_restore_cmd_called = true
+        post_restore_session_name = session_name
       end,
     },
     pre_delete_cmds = {
-      function()
+      function(session_name)
         pre_delete_cmd_called = true
+        pre_delete_session_name = session_name
       end,
     },
     post_delete_cmds = {
-      function()
+      function(session_name)
         post_delete_cmd_called = true
+        post_delete_session_name = session_name
       end,
     },
 
@@ -64,6 +72,7 @@ describe("Hooks", function()
     assert.True(pre_save_cmd_called)
     assert.True(post_save_cmd_called)
     assert.equals(TL.default_session_name, pre_save_session_name)
+    assert.equals(TL.default_session_name, post_save_session_name)
   end)
 
   it("fire when restoring", function()
@@ -78,6 +87,7 @@ describe("Hooks", function()
     assert.True(pre_restore_cmd_called)
     assert.True(post_restore_cmd_called)
     assert.equals(TL.default_session_name, pre_restore_session_name)
+    assert.equals(TL.default_session_name, post_restore_session_name)
   end)
 
   it("fire when deleting", function()
@@ -88,6 +98,8 @@ describe("Hooks", function()
 
     assert.True(pre_delete_cmd_called)
     assert.True(post_delete_cmd_called)
+    assert.equals(TL.default_session_name, pre_delete_session_name)
+    assert.equals(TL.default_session_name, post_delete_session_name)
   end)
 
   it("pre_save returning false stops auto-save but not save", function()

--- a/tests/hooks_spec.lua
+++ b/tests/hooks_spec.lua
@@ -3,49 +3,48 @@ local TL = require("tests/test_lib")
 
 describe("Hooks", function()
   local as = require("auto-session")
+  local c = require("auto-session.config")
   local pre_save_cmd_called = false
+  local pre_save_session_name
   local post_save_cmd_called = false
   local pre_restore_cmd_called = false
+  local pre_restore_session_name
   local post_restore_cmd_called = false
   local pre_delete_cmd_called = false
   local post_delete_cmd_called = false
 
   as.setup({
     pre_save_cmds = {
-      function()
-        print("pre_save_cmd")
+      function(session_name)
+        -- print("pre_save_cmd")
         pre_save_cmd_called = true
-        assert.equals(0, vim.fn.filereadable(TL.default_session_path))
+        pre_save_session_name = session_name
       end,
     },
     post_save_cmds = {
       function()
-        print("post_save_cmd")
+        -- print("post_save_cmd")
         post_save_cmd_called = true
-        assert.equals(1, vim.fn.filereadable(TL.default_session_path))
       end,
     },
     pre_restore_cmds = {
-      function()
-        assert.equals(0, vim.fn.bufexists(TL.test_file))
+      function(session_name)
         pre_restore_cmd_called = true
+        pre_restore_session_name = session_name
       end,
     },
     post_restore_cmds = {
       function()
-        assert.equals(1, vim.fn.bufexists(TL.test_file))
         post_restore_cmd_called = true
       end,
     },
     pre_delete_cmds = {
       function()
-        assert.equals(1, vim.fn.filereadable(TL.default_session_path))
         pre_delete_cmd_called = true
       end,
     },
     post_delete_cmds = {
       function()
-        assert.equals(0, vim.fn.filereadable(TL.default_session_path))
         post_delete_cmd_called = true
       end,
     },
@@ -59,11 +58,12 @@ describe("Hooks", function()
   it("fire when saving", function()
     vim.cmd("e " .. TL.test_file)
 
-    assert.True(as.auto_save_session())
+    assert.True(as.save_session())
     assert.equals(1, vim.fn.filereadable(TL.default_session_path))
 
     assert.True(pre_save_cmd_called)
     assert.True(post_save_cmd_called)
+    assert.equals(TL.default_session_name, pre_save_session_name)
   end)
 
   it("fire when restoring", function()
@@ -77,6 +77,7 @@ describe("Hooks", function()
 
     assert.True(pre_restore_cmd_called)
     assert.True(post_restore_cmd_called)
+    assert.equals(TL.default_session_name, pre_restore_session_name)
   end)
 
   it("fire when deleting", function()
@@ -87,5 +88,80 @@ describe("Hooks", function()
 
     assert.True(pre_delete_cmd_called)
     assert.True(post_delete_cmd_called)
+  end)
+
+  it("pre_save returning false stops auto-save but not save", function()
+    TL.clearSessionFilesAndBuffers()
+    vim.cmd("e " .. TL.test_file)
+
+    -- re-enable auto-save because test above deletes the current session
+    -- which disables auto-save
+    c.auto_save = true
+    c.pre_save_cmds = {
+      function()
+        pre_save_cmd_called = true
+        print("returning false in pre_save_cmds")
+        return false
+      end,
+    }
+
+    pre_save_cmd_called = false
+    post_save_cmd_called = false
+
+    assert.False(as.auto_save_session())
+
+    assert.equals(0, vim.fn.filereadable(TL.default_session_path))
+
+    assert.True(pre_save_cmd_called)
+    assert.False(post_save_cmd_called)
+
+    -- now make sure non-auto save works
+
+    pre_save_cmd_called = false
+    post_save_cmd_called = false
+
+    assert.True(as.save_session())
+
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+
+    assert.True(pre_save_cmd_called)
+    assert.True(post_save_cmd_called)
+  end)
+
+  it("pre_restore returning false stops auto-restore but not restore", function()
+    vim.cmd("%bw")
+
+    assert.equals(0, vim.fn.bufexists(TL.test_file))
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+
+    c.pre_restore_cmds = {
+      function()
+        pre_restore_cmd_called = true
+        print("returning false in pre_restore_cmds")
+        return false
+      end,
+    }
+
+    -- make sure auto-restore can be stopped
+
+    pre_restore_cmd_called = false
+    post_restore_cmd_called = false
+
+    assert.False(as.auto_restore_session(nil, true))
+
+    assert.True(pre_restore_cmd_called)
+    assert.False(post_restore_cmd_called)
+    assert.equals(0, vim.fn.bufexists(TL.test_file))
+
+    -- now make sure non-auto restore works
+
+    pre_restore_cmd_called = false
+    post_restore_cmd_called = false
+
+    assert.True(as.restore_session())
+
+    assert.True(pre_restore_cmd_called)
+    assert.True(post_restore_cmd_called)
+    assert.equals(1, vim.fn.bufexists(TL.test_file))
   end)
 end)


### PR DESCRIPTION
`pre_save` and `pre_restore` are now passed the session name (this
supercedes https://github.com/rmagatti/auto-session/issues/443) and if one of the cmds returns false, then auto saving
or restoring are prevented.

Fixes https://github.com/rmagatti/auto-session/issues/493

Marked as breaking in the unlikely case someone has an existing hook
that happens to be returning false already

Also, refactor logger to use Config.log_level directly