### PR TITLE
fix(health): Lib.logger is empty normally now

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ local defaults = {
 ---@field post_restore_cmds? (string|fun(session_name:string))[] executes after a session is restored
 ---@field pre_delete_cmds? (string|fun(session_name:string))[] executes before a session is deleted
 ---@field post_delete_cmds? (string|fun(session_name:string))[] executes after a session is deleted
----@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
----@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
----@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
----@field save_extra_cmds? table executes before a session is saved
+---@field no_restore_cmds? (string|fun(is_startup:boolean))[] executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
+---@field pre_cwd_changed_cmds? (string|fun())[] executes before cwd is changed if cwd_change_handling is true
+---@field post_cwd_changed_cmds? (string|fun())[] executes after cwd is changed if cwd_change_handling is true
+---@field save_extra_cmds? (string|fun(session_name:string): extra_data:string|table|nil)[] executes to get extra data to save with the session
 ```
 
 <!-- types:end -->

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,4 @@
-*auto-session.txt*           For Neovim           Last change: 2025 October 03
+*auto-session.txt*           For Neovim           Last change: 2025 October 07
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -219,10 +219,10 @@ Types ~
     ---@field post_restore_cmds? (string|fun(session_name:string))[] executes after a session is restored
     ---@field pre_delete_cmds? (string|fun(session_name:string))[] executes before a session is deleted
     ---@field post_delete_cmds? (string|fun(session_name:string))[] executes after a session is deleted
-    ---@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
-    ---@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
-    ---@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
-    ---@field save_extra_cmds? table executes before a session is saved
+    ---@field no_restore_cmds? (string|fun(is_startup:boolean))[] executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
+    ---@field pre_cwd_changed_cmds? (string|fun())[] executes before cwd is changed if cwd_change_handling is true
+    ---@field post_cwd_changed_cmds? (string|fun())[] executes after cwd is changed if cwd_change_handling is true
+    ---@field save_extra_cmds? (string|fun(session_name:string): extra_data:string|table|nil)[] executes to get extra data to save with the session
 <
 
 

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -78,10 +78,10 @@ local M = {}
 ---@field post_restore_cmds? (string|fun(session_name:string))[] executes after a session is restored
 ---@field pre_delete_cmds? (string|fun(session_name:string))[] executes before a session is deleted
 ---@field post_delete_cmds? (string|fun(session_name:string))[] executes after a session is deleted
----@field no_restore_cmds? table executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
----@field pre_cwd_changed_cmds? table executes before cwd is changed if cwd_change_handling is true
----@field post_cwd_changed_cmds? table executes after cwd is changed if cwd_change_handling is true
----@field save_extra_cmds? table executes before a session is saved
+---@field no_restore_cmds? (string|fun(is_startup:boolean))[] executes when no session is restored when auto-restoring, happens on startup or possibly on cwd/git branch changes
+---@field pre_cwd_changed_cmds? (string|fun())[] executes before cwd is changed if cwd_change_handling is true
+---@field post_cwd_changed_cmds? (string|fun())[] executes after cwd is changed if cwd_change_handling is true
+---@field save_extra_cmds? (string|fun(session_name:string): extra_data:string|table|nil)[] executes to get extra data to save with the session
 
 ---@type AutoSession.Config
 local defaults = {

--- a/lua/auto-session/health.lua
+++ b/lua/auto-session/health.lua
@@ -75,7 +75,7 @@ end
 
 function M.check()
   start("Setup")
-  if not Config.root_dir or vim.tbl_isempty(Lib.logger) then
+  if not Config.root_dir or not vim.g.loaded_auto_session then
     error(
       "Setup was not called. Auto-session will not work unless you call setup() somewhere, e.g.:\n\n"
         .. "require('auto-session').setup({})"


### PR DESCRIPTION
We don't store any state in Lib.logger anymore so vim.tbl_isempty is false (methods in the metatable don't count)

Fixes issue mentioned in #495 