### PR TITLE
fix(start): if disabled, don't do anything in start

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -505,6 +505,10 @@ end
 ---Will call auto_restore_session_at_vim_enter and also purge sessions (if enabled)
 ---@return boolean # Was a session restored
 function AutoSession.start()
+  if not Config.enabled then
+    return false
+  end
+
   local did_auto_restore = AutoSession.auto_restore_session_at_vim_enter()
 
   if Config.purge_after_minutes then


### PR DESCRIPTION
We were already checking for enabled deeper down in the code but that would result in no_restore_cmds being triggerd. If we're disabled, be really disabled.

Fixes #500