### PR TITLE
Fix: Ensure buffers are loaded before restoring breakpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,13 @@ local opts = {
             log_message = bp.logMessage,
             hit_condition = bp.hitCondition,
           }
-          breakpoints.set(opts, vim.fn.bufnr(buf_name), line)
+
+          local bufnr = vim.fn.bufnr(buf_name, true)
+          if vim.fn.bufloaded(bufnr) == 0 then
+            vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
+          end
+
+          breakpoints.set(opts, bufnr, line)
         end
       end
     end

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -657,7 +657,13 @@ As an example, here’s how you could save DAP breakpoints with your session:
                 log_message = bp.logMessage,
                 hit_condition = bp.hitCondition,
               }
-              breakpoints.set(opts, vim.fn.bufnr(buf_name), line)
+
+              local bufnr = vim.fn.bufnr(buf_name, true)
+              if vim.fn.bufloaded(bufnr) == 0 then
+                vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
+              end
+
+              breakpoints.set(opts, bufnr, line)
             end
           end
         end


### PR DESCRIPTION
Hi,
This PR addresses the issue mentioned in #436.

As the title suggests, the fix is straightforward.
If a buffer is not loaded when restoring breakpoints, load it first.

Greetings