### PR TITLE
fix: gracefully close snacks terminals on save

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,5 @@
-*auto-session.txt*           For Neovim          Last change: 2026 February 08
+*auto-session.txt*
+                                      For Neovim    Last change: 2026 April 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -676,12 +677,12 @@ As an example, here’s how you could save DAP breakpoints with your session:
                 log_message = bp.logMessage,
                 hit_condition = bp.hitCondition,
               }
-
+    
               local bufnr = vim.fn.bufnr(buf_name, true)
               if vim.fn.bufloaded(bufnr) == 0 then
                 vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
               end
-
+    
               breakpoints.set(opts, bufnr, line)
             end
           end

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -997,6 +997,26 @@ end
 
 ---Close any buffers that have a ft that is in ignored_filetypes
 ---@param ignored_filetypes table list of filetypes to close
+local function close_buffer(buf)
+  if vim.bo[buf].buftype == "terminal" and vim.bo[buf].filetype == "snacks_terminal" then
+    local job_id = vim.b[buf].terminal_job_id
+
+    if job_id and job_id > 0 then
+      pcall(vim.api.nvim_chan_send, job_id, "exit\n")
+      vim.fn.jobwait({ job_id }, 1000)
+      vim.wait(1000, function()
+        return not vim.api.nvim_buf_is_valid(buf)
+      end, 10)
+
+      if not vim.api.nvim_buf_is_valid(buf) then
+        return
+      end
+    end
+  end
+
+  vim.api.nvim_buf_delete(buf, { force = true })
+end
+
 function Lib.close_ignored_filetypes(ignored_filetypes)
   local filetypes_to_ignore = ignored_filetypes or {}
   if vim.tbl_isempty(filetypes_to_ignore) then
@@ -1009,7 +1029,7 @@ function Lib.close_ignored_filetypes(ignored_filetypes)
     if vim.api.nvim_buf_is_loaded(buf) then
       local buf_ft = vim.bo[buf].filetype
       if buf_ft and vim.tbl_contains(filetypes_to_ignore, buf_ft) then
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_buffer(buf)
         break
       end
     end

--- a/tests/close_filetypes_on_save_spec.lua
+++ b/tests/close_filetypes_on_save_spec.lua
@@ -66,4 +66,52 @@ describe("Close filetypes on save", function()
     -- Check that the checkhealth file is not in the session
     assert.False(TL.sessionHasFile(TL.default_session_path, "health://"))
   end)
+
+  TL.clearSessionFilesAndBuffers()
+
+  it("gracefully closes snacks_terminal buffers before saving", function()
+    local notifications = {}
+    local original_notify = vim.notify
+
+    vim.notify = function(msg, level, opts)
+      table.insert(notifications, { msg = msg, level = level, opts = opts })
+    end
+
+    vim.cmd("enew")
+    local terminal_buf = vim.api.nvim_get_current_buf()
+
+    local terminal_closed = false
+    vim.api.nvim_create_autocmd("TermClose", {
+      buffer = terminal_buf,
+      callback = function()
+        if type(vim.v.event) == "table" and vim.v.event.status ~= 0 then
+          vim.notify("Terminal exited with code " .. vim.v.event.status .. ".\nCheck for any errors.")
+          return
+        end
+        terminal_closed = true
+      end,
+    })
+
+    vim.fn.termopen({ vim.o.shell, "-c", "while IFS= read -r line; do [ \"$line\" = exit ] && exit 0; done" })
+    vim.bo[terminal_buf].filetype = "snacks_terminal"
+
+    as.setup({
+      close_filetypes_on_save = { "snacks_terminal" },
+    })
+
+    local ok = pcall(as.auto_save_session)
+
+    vim.notify = original_notify
+
+    assert.True(ok)
+    vim.wait(1000, function()
+      return terminal_closed
+    end, 10)
+    assert.True(terminal_closed)
+    assert.False(vim.api.nvim_buf_is_valid(terminal_buf))
+
+    for _, notification in ipairs(notifications) do
+      assert.is_nil(notification.msg:match("Terminal exited with code %-1"))
+    end
+  end)
 end)


### PR DESCRIPTION
## Summary
- Gracefully close `snacks_terminal` buffers before falling back to forced deletion during session saves.
- Add regression coverage so switching sessions does not trigger the `TermClose` exit `-1` failure path.

## Testing
- `make tests/close_filetypes_on_save_spec.lua`
- `make tests/auto_save_spec.lua`
- `make tests/session_control_spec.lua`
- `make tests/lib_spec.lua`

Fixes #508