### PR TITLE
fix(save): close all ignored filetype buffers

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,5 @@
-*auto-session.txt*           For Neovim          Last change: 2026 February 08
+*auto-session.txt*
+                                      For Neovim    Last change: 2026 April 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -676,12 +677,12 @@ As an example, here’s how you could save DAP breakpoints with your session:
                 log_message = bp.logMessage,
                 hit_condition = bp.hitCondition,
               }
-
+    
               local bufnr = vim.fn.bufnr(buf_name, true)
               if vim.fn.bufloaded(bufnr) == 0 then
                 vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
               end
-
+    
               breakpoints.set(opts, bufnr, line)
             end
           end

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -1010,7 +1010,6 @@ function Lib.close_ignored_filetypes(ignored_filetypes)
       local buf_ft = vim.bo[buf].filetype
       if buf_ft and vim.tbl_contains(filetypes_to_ignore, buf_ft) then
         vim.api.nvim_buf_delete(buf, { force = true })
-        break
       end
     end
   end

--- a/tests/close_filetypes_on_save_spec.lua
+++ b/tests/close_filetypes_on_save_spec.lua
@@ -47,6 +47,25 @@ describe("Close filetypes on save", function()
 
   TL.clearSessionFilesAndBuffers()
 
+  it("closes all buffers of matching filetypes before saving", function()
+    vim.cmd("e " .. TL.test_file) -- this is a text file
+    vim.cmd("e " .. TL.other_file) -- this is also a text file
+    vim.cmd("e tests/close_filetypes_on_save_spec.lua")
+
+    as.setup({
+      close_filetypes_on_save = { "text" },
+    })
+
+    assert.True(as.auto_save_session())
+    assert.equals(1, vim.fn.filereadable(TL.default_session_path))
+
+    assert.False(TL.sessionHasFile(TL.default_session_path, TL.test_file))
+    assert.False(TL.sessionHasFile(TL.default_session_path, TL.other_file))
+    assert.True(TL.sessionHasFile(TL.default_session_path, "tests/close_filetypes_on_save_spec.lua"))
+  end)
+
+  TL.clearSessionFilesAndBuffers()
+
   it("does not save a checkhealth buffer", function()
     vim.cmd("e " .. TL.test_file) -- this is a text file
     vim.cmd("checkhealth auto-session")


### PR DESCRIPTION
## Summary
- Close every buffer whose filetype matches `close_filetypes_on_save` instead of stopping after the first match.
- Add regression coverage so sidekick-style transient buffers are removed before the session is written.

## Testing
- `make tests/close_filetypes_on_save_spec.lua`
- `make tests/restore_error_handler_spec.lua`
- `make tests/hooks_spec.lua`

Fixes #507