### PR TITLE
fix(git): watch HEAD from repo root

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,5 @@
-*auto-session.txt*           For Neovim          Last change: 2026 February 08
+*auto-session.txt*
+                                      For Neovim    Last change: 2026 April 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -676,12 +677,12 @@ As an example, here’s how you could save DAP breakpoints with your session:
                 log_message = bp.logMessage,
                 hit_condition = bp.hitCondition,
               }
-
+    
               local bufnr = vim.fn.bufnr(buf_name, true)
               if vim.fn.bufloaded(bufnr) == 0 then
                 vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
               end
-
+    
               breakpoints.set(opts, bufnr, line)
             end
           end

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,5 @@
 *auto-session.txt*
-                                      For Neovim    Last change: 2026 April 15
+                                     For Neovim    Last change: 2026 August 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -94,13 +94,14 @@ Default settings (you don’t have to copy these into your config):
       allowed_dirs = nil, -- Allow session restore/create in certain directories
       bypass_save_filetypes = nil, -- List of filetypes to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
       close_filetypes_on_save = { "checkhealth" }, -- Buffers with matching filetypes will be closed before saving
-      close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session
+      close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session. Set preserve_filetypes/preserve_buftypes to keep selected unsupported windows open.
       preserve_buffer_on_restore = nil, -- Function that returns true if a buffer should be preserved when restoring a session
     
       -- Git / Session naming
       git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
       git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
       custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+      resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
     
       -- Deleting
       auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving
@@ -130,6 +131,7 @@ Default settings (you don’t have to copy these into your config):
         load_on_setup = true, -- Only used for telescope, registers the telescope extension at startup so you can use :Telescope session-lens
         picker_opts = nil, -- Table passed to Telescope / Snacks / Fzf-Lua to configure the picker. See below for more information
         previewer = "summary", -- 'summary'|'active_buffer'|function - How to display session preview. 'summary' shows a summary of the session, 'active_buffer' shows the contents of the active buffer in the session, or a custom function
+        shorten_paths = true, -- Replace the home directory with ~ in the picker display names
     
         ---@type SessionLensMappings
         mappings = {
@@ -167,13 +169,14 @@ Types ~
     ---@field allowed_dirs? table
     ---@field bypass_save_filetypes? table
     ---@field close_filetypes_on_save? table
-    ---@field close_unsupported_windows? boolean
+    ---@field close_unsupported_windows? boolean|AutoSession.CloseUnsupportedWindowsOpts
     ---@field preserve_buffer_on_restore? fun(bufnr:number): preserve_buffer:boolean
     ---
     ---Git / Session naming
     ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
     ---@field git_auto_restore_on_branch_change? boolean
     ---@field custom_session_tag? fun(session_name:string): tag:string
+    ---@field resolve_symlinks? boolean
     ---
     ---Deleting
     ---@field auto_delete_empty_sessions? boolean
@@ -205,6 +208,7 @@ Types ~
     ---@field load_on_setup? boolean
     ---@field picker_opts? table
     ---@field previewer? 'summary'|'active_buffer'|fun(session_name:string, session_filename:string, session_lines:string[]):lines:string[],filetype:string?
+    ---@field shorten_paths? boolean
     ---@field mappings? SessionLensMappings
     ---@field session_control? SessionControl
     ---
@@ -602,6 +606,9 @@ are some examples of what you can do:
       },
     
       -- Save quickfix list and open it when restoring the session
+      close_unsupported_windows = {
+        preserve_buftypes = { "quickfix" },
+      },
       save_extra_cmds = {
         function()
           local qflist = vim.fn.getqflist()

--- a/lua/auto-session/git.lua
+++ b/lua/auto-session/git.lua
@@ -8,6 +8,22 @@ local M = {}
 
 M.uv_git_watcher = nil
 
+---@param cwd string current working directory
+---@param towatch string file to watch, should be something like .git/HEAD
+---@return string
+local function resolve_watch_path(cwd, towatch)
+  local git_path = towatch:gsub("^%.git[/\\]", "")
+  local git_cmd =
+    string.format("git -C %s rev-parse --path-format=absolute --git-path %s", vim.fn.shellescape(cwd), git_path)
+  local out = vim.fn.systemlist(git_cmd)
+
+  if vim.v.shell_error ~= 0 or not out[1] or out[1] == "" then
+    return vim.fs.normalize(vim.fs.joinpath(cwd, towatch))
+  end
+
+  return vim.fs.normalize(out[1])
+end
+
 function M.on_git_watch_event(cwd, current_branch)
   local new_branch = Lib.get_git_branch_name(cwd, Config.git_use_branch_name)
 
@@ -68,12 +84,13 @@ function M.start_watcher(cwd, towatch)
 
   M.uv_git_watcher = assert(uv.new_fs_event())
   local current_branch = Lib.get_git_branch_name(cwd, Config.git_use_branch_name)
+  local watch_path = resolve_watch_path(cwd, towatch)
 
-  Lib.logger.debug("Git: starting watcher", { cwd, current_branch })
+  Lib.logger.debug("Git: starting watcher", { cwd, current_branch, watch_path })
 
   -- Watch .git/HEAD to detect branch changes
   M.uv_git_watcher:start(
-    towatch,
+    watch_path,
     {},
     Lib.debounce(function(err)
       if err then

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -205,6 +205,41 @@ describe("The git config", function()
     c.auto_save = false
   end)
 
+  it("watches git HEAD from the repo root when started in a subdirectory", function()
+    local repo_root = vim.fn.getcwd()
+    local nested_dir = repo_root .. "/nested"
+    vim.fn.mkdir(nested_dir, "p")
+    local uv = vim.uv or vim.loop
+
+    local watcher
+    watcher = {
+      path = nil,
+      start = function(_, path)
+        watcher.path = path
+      end,
+      stop = function() end,
+    }
+
+    local uv_new_fs_event = uv.new_fs_event
+    uv.new_fs_event = function()
+      return watcher
+    end
+
+    local ok, err = pcall(function()
+      vim.cmd("cd " .. nested_dir)
+      g.start_watcher(vim.fn.getcwd(), ".git/HEAD")
+      assert.equals(repo_root .. "/.git/HEAD", watcher.path)
+    end)
+
+    uv.new_fs_event = uv_new_fs_event
+    g.stop_watcher()
+    vim.cmd("cd " .. repo_root)
+
+    if not ok then
+      error(err)
+    end
+  end)
+
   it("auto-restores after a branch change", function()
     c.auto_save = true
     c.git_auto_restore_on_branch_change = true


### PR DESCRIPTION
## Summary
- Resolve the watched git `HEAD` path through `git rev-parse` so branch watching works when Neovim starts in a nested subdirectory.
- Add regression coverage for subdirectory startup and watcher path resolution.

## Testing
- `make tests/git_spec.lua`

## Notes
- `make plenary-tests` still hits pre-existing purge test failures in `tests/cmds_spec.lua` and `tests/legacy_cmds_spec.lua`.

Fixes #515