### PR TITLE
fix: escape # in session save paths

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,5 @@
-*auto-session.txt*           For Neovim          Last change: 2026 February 08
+*auto-session.txt*
+                                      For Neovim    Last change: 2026 April 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -676,12 +677,12 @@ As an example, here’s how you could save DAP breakpoints with your session:
                 log_message = bp.logMessage,
                 hit_condition = bp.hitCondition,
               }
-
+    
               local bufnr = vim.fn.bufnr(buf_name, true)
               if vim.fn.bufloaded(bufnr) == 0 then
                 vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
               end
-
+    
               breakpoints.set(opts, bufnr, line)
             end
           end

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,5 @@
 *auto-session.txt*
-                                      For Neovim    Last change: 2026 April 15
+                                     For Neovim    Last change: 2026 August 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -94,13 +94,14 @@ Default settings (you don’t have to copy these into your config):
       allowed_dirs = nil, -- Allow session restore/create in certain directories
       bypass_save_filetypes = nil, -- List of filetypes to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
       close_filetypes_on_save = { "checkhealth" }, -- Buffers with matching filetypes will be closed before saving
-      close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session
+      close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session. Set preserve_filetypes/preserve_buftypes to keep selected unsupported windows open.
       preserve_buffer_on_restore = nil, -- Function that returns true if a buffer should be preserved when restoring a session
     
       -- Git / Session naming
       git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
       git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
       custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+      resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
     
       -- Deleting
       auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving
@@ -130,6 +131,7 @@ Default settings (you don’t have to copy these into your config):
         load_on_setup = true, -- Only used for telescope, registers the telescope extension at startup so you can use :Telescope session-lens
         picker_opts = nil, -- Table passed to Telescope / Snacks / Fzf-Lua to configure the picker. See below for more information
         previewer = "summary", -- 'summary'|'active_buffer'|function - How to display session preview. 'summary' shows a summary of the session, 'active_buffer' shows the contents of the active buffer in the session, or a custom function
+        shorten_paths = true, -- Replace the home directory with ~ in the picker display names
     
         ---@type SessionLensMappings
         mappings = {
@@ -167,13 +169,14 @@ Types ~
     ---@field allowed_dirs? table
     ---@field bypass_save_filetypes? table
     ---@field close_filetypes_on_save? table
-    ---@field close_unsupported_windows? boolean
+    ---@field close_unsupported_windows? boolean|AutoSession.CloseUnsupportedWindowsOpts
     ---@field preserve_buffer_on_restore? fun(bufnr:number): preserve_buffer:boolean
     ---
     ---Git / Session naming
     ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
     ---@field git_auto_restore_on_branch_change? boolean
     ---@field custom_session_tag? fun(session_name:string): tag:string
+    ---@field resolve_symlinks? boolean
     ---
     ---Deleting
     ---@field auto_delete_empty_sessions? boolean
@@ -205,6 +208,7 @@ Types ~
     ---@field load_on_setup? boolean
     ---@field picker_opts? table
     ---@field previewer? 'summary'|'active_buffer'|fun(session_name:string, session_filename:string, session_lines:string[]):lines:string[],filetype:string?
+    ---@field shorten_paths? boolean
     ---@field mappings? SessionLensMappings
     ---@field session_control? SessionControl
     ---
@@ -602,6 +606,9 @@ are some examples of what you can do:
       },
     
       -- Save quickfix list and open it when restoring the session
+      close_unsupported_windows = {
+        preserve_buftypes = { "quickfix" },
+      },
       save_extra_cmds = {
         function()
           local qflist = vim.fn.getqflist()

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -253,11 +253,11 @@ function Lib.is_legacy_file_name(file_name)
   return false
 end
 
----Returns a sstring with % characters escaped, suitable for use with vim cmds
+---Returns a string escaped for use in Ex commands with file paths
 ---@param str string The string to vim escape
 ---@return string The string escaped for use with vim.cmd
 function Lib.escape_string_for_vim(str)
-  return (str:gsub("%%", "\\%%"))
+  return vim.fn.fnameescape(str)
 end
 
 -- NOTE: expand has the side effect of canonicalizing the path

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -148,6 +148,19 @@ describe("The git config", function()
     assert.equals(git_test_dir .. " (branch: slash/branch)", Lib.current_session_name(true))
   end)
 
+  it("saves a session with a # in the branch name", function()
+    runCmdAndPrint("git checkout main")
+    runCmdAndPrint("git checkout -b 'issue#516'")
+
+    local session_path = TL.session_dir .. TL.escapeSessionName(vim.fn.getcwd() .. "|issue#516") .. ".vim"
+
+    assert.True(as.save_session())
+    assert.equals(1, vim.fn.filereadable(session_path))
+    assert.equals(vim.fn.getcwd() .. " (branch: issue#516)", Lib.current_session_name())
+
+    runCmdAndPrint("git checkout main")
+  end)
+
   it("load a session named with git branch from . directory", function()
     c.args_allow_single_directory = true
     -- c.log_level = "debug"

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -150,7 +150,8 @@ describe("The git config", function()
 
   it("saves a session with a # in the branch name", function()
     runCmdAndPrint("git checkout main")
-    runCmdAndPrint("git checkout -b 'issue#516'")
+    -- Use the list form of system so no shell sees (and possibly mangles) the #
+    runCmdAndPrint({ "git", "checkout", "-b", "issue#516" })
 
     local session_path = TL.session_dir .. TL.escapeSessionName(vim.fn.getcwd() .. "|issue#516") .. ".vim"
 

--- a/tests/lib_spec.lua
+++ b/tests/lib_spec.lua
@@ -134,7 +134,7 @@ describe("Lib / Helper functions", function()
   end)
 
   it("escape_string_for_vim() works", function()
-    assert.equals("\\%some\\%dir\\%", Lib.escape_string_for_vim("%some%dir%"))
+    assert.equals("\\%some\\#dir\\%", Lib.escape_string_for_vim("%some#dir%"))
   end)
 
   it("can identify new and old sessions", function()


### PR DESCRIPTION
## Summary
- Use `vim.fn.fnameescape()` for session save and restore paths so branch names containing `#` are safe in Ex commands.
- Add regression coverage for `issue#516` branch names and the path escaping helper.

## Testing
- `make tests/lib_spec.lua`
- `make tests/git_spec.lua`

Fixes #516