### PR TITLE
fix: honor argv restore suppression for last session

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ local defaults = {
   restore_extra_data = nil, -- Function called when there's extra data saved for a session
 
   -- Argument handling
-  args_allow_single_directory = true, -- Follow normal session save/load logic if launched with a single directory as the only argument
-  args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not load any existing session first. Can be true or a function that returns true when saving is allowed. See documentation for more detail
+  args_allow_single_directory = true, -- Follow normal session restore/save logic if launched with a single directory as the only argument. Set to false to skip auto-restore when any argument is passed to Neovim
+  args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not re-enable auto-restore and can be true or a function that returns true when saving is allowed. See documentation for more detail
 
   -- Misc
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
@@ -259,6 +259,7 @@ Starting `nvim`
 - When starting `nvim` with no arguments, AutoSession will try to restore the session for `cwd` if one exists.
 - When starting `nvim .` (or another directory), AutoSession will try to restore the session for that directory. See [argument handling](https://github.com/rmagatti/auto-session/wiki/Argument-Handling) for more details.
 - When starting `nvim some_file.txt` (or multiple files), by default, AutoSession won't do anything. See [argument handling](https://github.com/rmagatti/auto-session/wiki/Argument-Handling) for more details.
+- Set `args_allow_single_directory = false` if you want startup restore to be skipped whenever any command-line argument is passed. `args_allow_files_auto_save` still only controls whether autosave is allowed for file or mixed arguments.
 - Even after starting `nvim` with a file argument, a session for `cwd` can still be manually restored by running `:AutoSession restore`.
 - When piping to `nvim`, e.g: `cat myfile | nvim`, AutoSession disables itself.
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,4 +1,5 @@
-*auto-session.txt*           For Neovim          Last change: 2026 February 08
+*auto-session.txt*
+                                      For Neovim    Last change: 2026 April 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -110,8 +111,8 @@ Default settings (you don’t have to copy these into your config):
       restore_extra_data = nil, -- Function called when there's extra data saved for a session
     
       -- Argument handling
-      args_allow_single_directory = true, -- Follow normal session save/load logic if launched with a single directory as the only argument
-      args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not load any existing session first. Can be true or a function that returns true when saving is allowed. See documentation for more detail
+      args_allow_single_directory = true, -- Follow normal session restore/save logic if launched with a single directory as the only argument. Set to false to skip auto-restore when any argument is passed to Neovim
+      args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not re-enable auto-restore and can be true or a function that returns true when saving is allowed. See documentation for more detail
     
       -- Misc
       log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).
@@ -279,6 +280,7 @@ Starting `nvim`
 - When starting `nvim` with no arguments, AutoSession will try to restore the session for `cwd` if one exists.
 - When starting `nvim .` (or another directory), AutoSession will try to restore the session for that directory. See argument handling <https://github.com/rmagatti/auto-session/wiki/Argument-Handling> for more details.
 - When starting `nvim some_file.txt` (or multiple files), by default, AutoSession won’t do anything. See argument handling <https://github.com/rmagatti/auto-session/wiki/Argument-Handling> for more details.
+- Set `args_allow_single_directory = false` if you want startup restore to be skipped whenever any command-line argument is passed. `args_allow_files_auto_save` still only controls whether autosave is allowed for file or mixed arguments.
 - Even after starting `nvim` with a file argument, a session for `cwd` can still be manually restored by running `:AutoSession restore`.
 - When piping to `nvim`, e.g: `cat myfile | nvim`, AutoSession disables itself.
 
@@ -676,12 +678,12 @@ As an example, here’s how you could save DAP breakpoints with your session:
                 log_message = bp.logMessage,
                 hit_condition = bp.hitCondition,
               }
-
+    
               local bufnr = vim.fn.bufnr(buf_name, true)
               if vim.fn.bufloaded(bufnr) == 0 then
                 vim.api.nvim_buf_call(bufnr, vim.cmd.edit)
               end
-
+    
               breakpoints.set(opts, bufnr, line)
             end
           end

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,5 @@
 *auto-session.txt*
-                                      For Neovim    Last change: 2026 April 15
+                                     For Neovim    Last change: 2026 August 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -94,13 +94,14 @@ Default settings (you don’t have to copy these into your config):
       allowed_dirs = nil, -- Allow session restore/create in certain directories
       bypass_save_filetypes = nil, -- List of filetypes to bypass auto save when the only buffer open is one of the file types listed, useful to ignore dashboards
       close_filetypes_on_save = { "checkhealth" }, -- Buffers with matching filetypes will be closed before saving
-      close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session
+      close_unsupported_windows = true, -- Close windows that aren't backed by normal file before autosaving a session. Set preserve_filetypes/preserve_buftypes to keep selected unsupported windows open.
       preserve_buffer_on_restore = nil, -- Function that returns true if a buffer should be preserved when restoring a session
     
       -- Git / Session naming
       git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
       git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
       custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+      resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
     
       -- Deleting
       auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving
@@ -130,6 +131,7 @@ Default settings (you don’t have to copy these into your config):
         load_on_setup = true, -- Only used for telescope, registers the telescope extension at startup so you can use :Telescope session-lens
         picker_opts = nil, -- Table passed to Telescope / Snacks / Fzf-Lua to configure the picker. See below for more information
         previewer = "summary", -- 'summary'|'active_buffer'|function - How to display session preview. 'summary' shows a summary of the session, 'active_buffer' shows the contents of the active buffer in the session, or a custom function
+        shorten_paths = true, -- Replace the home directory with ~ in the picker display names
     
         ---@type SessionLensMappings
         mappings = {
@@ -167,13 +169,14 @@ Types ~
     ---@field allowed_dirs? table
     ---@field bypass_save_filetypes? table
     ---@field close_filetypes_on_save? table
-    ---@field close_unsupported_windows? boolean
+    ---@field close_unsupported_windows? boolean|AutoSession.CloseUnsupportedWindowsOpts
     ---@field preserve_buffer_on_restore? fun(bufnr:number): preserve_buffer:boolean
     ---
     ---Git / Session naming
     ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
     ---@field git_auto_restore_on_branch_change? boolean
     ---@field custom_session_tag? fun(session_name:string): tag:string
+    ---@field resolve_symlinks? boolean
     ---
     ---Deleting
     ---@field auto_delete_empty_sessions? boolean
@@ -205,6 +208,7 @@ Types ~
     ---@field load_on_setup? boolean
     ---@field picker_opts? table
     ---@field previewer? 'summary'|'active_buffer'|fun(session_name:string, session_filename:string, session_lines:string[]):lines:string[],filetype:string?
+    ---@field shorten_paths? boolean
     ---@field mappings? SessionLensMappings
     ---@field session_control? SessionControl
     ---
@@ -603,6 +607,9 @@ are some examples of what you can do:
       },
     
       -- Save quickfix list and open it when restoring the session
+      close_unsupported_windows = {
+        preserve_buftypes = { "quickfix" },
+      },
       save_extra_cmds = {
         function()
           local qflist = vim.fn.getqflist()

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -118,8 +118,8 @@ local defaults = {
   restore_extra_data = nil, -- Function called when there's extra data saved for a session
 
   -- Argument handling
-  args_allow_single_directory = true, -- Follow normal session save/load logic if launched with a single directory as the only argument
-  args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not load any existing session first. Can be true or a function that returns true when saving is allowed. See documentation for more detail
+  args_allow_single_directory = true, -- Follow normal session restore/save logic if launched with a single directory as the only argument. Set to false to skip auto-restore when any argument is passed to Neovim
+  args_allow_files_auto_save = false, -- Allow saving a session even when launched with a file argument (or multiple files/dirs). It does not re-enable auto-restore and can be true or a function that returns true when saving is allowed. See documentation for more detail
 
   -- Misc
   log_level = "error", -- Sets the log level of the plugin (debug, info, warn, error).

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -540,6 +540,8 @@ function AutoSession.auto_restore_session_at_vim_enter()
   -- is important because some plugins (.e.g. NvimTree) rewrite the arguments before
   -- we get to see them
 
+  local restore_allowed_for_argv = enabled_for_command_line_argv(false)
+
   -- Is there exactly one argument and is it a directory?
   if
     Config.args_allow_single_directory
@@ -571,12 +573,12 @@ function AutoSession.auto_restore_session_at_vim_enter()
       Config.auto_save = false
     end
   else
-    if AutoSession.auto_restore_session(nil, true) then
+    if restore_allowed_for_argv and AutoSession.auto_restore_session(nil, true) then
       return true
     end
 
     -- Check to see if the last session feature is on
-    if Config.auto_restore_last_session then
+    if restore_allowed_for_argv and Config.auto_restore_last_session then
       Lib.logger.debug("Last session is enabled, checking for session")
       local last_session_name = Lib.get_latest_session(AutoSession.get_root_dir())
       if last_session_name then

--- a/tests/args_not_enabled_spec.lua
+++ b/tests/args_not_enabled_spec.lua
@@ -77,4 +77,26 @@ describe("The args not enabled config", function()
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
   end)
+
+  it("doesn't restore the last session when run with a file", function()
+    no_restore_hook_called = false
+    c.auto_restore_last_session = true
+
+    local s = stub(vim.fn, "argv")
+    s.returns({ TL.other_file })
+
+    -- have to call setup again for auto-session to recapture argv
+    as.setup(c.options)
+
+    -- only exported because we set the unit testing env in TL
+    assert.equals(false, require("auto-session").auto_restore_session_at_vim_enter())
+
+    -- Revert the stub
+    vim.fn.argv:revert()
+    c.auto_restore_last_session = false
+
+    assert.equals(true, no_restore_hook_called)
+
+    assert.equals(0, vim.fn.bufexists(TL.test_file))
+  end)
 end)


### PR DESCRIPTION
## Summary
- Apply existing argv restore suppression to `auto_restore_last_session` so `nvim <arg>` can skip auto-restoring consistently.
- Add regression coverage for file arguments when last-session restore is enabled.

## Testing
- `make tests/args_not_enabled_spec.lua`
- `make tests/args_single_dir_enabled_spec.lua`
- `make tests/args_files_enabled_spec.lua`
- `make tests/last_session_spec.lua`

## Notes
- `make plenary-tests` still hits pre-existing purge test failures in `tests/cmds_spec.lua` and `tests/legacy_cmds_spec.lua`.

Closes #514