### PR TITLE
fix: use Client:stop for lsp_stop_on_restore

### DIFF
--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -818,7 +818,9 @@ function AutoSession.restore_session_file(session_path, opts)
       else
         local clients = vim.lsp.get_clients()
         if #clients > 0 then
-          vim.lsp.stop_client(clients)
+          for _, client in ipairs(clients) do
+            client:stop()
+          end
         end
       end
     end

--- a/tests/ls_stop_on_restore_spec.lua
+++ b/tests/ls_stop_on_restore_spec.lua
@@ -1,4 +1,5 @@
 local TL = require("tests/test_lib")
+local stub = require("luassert.stub")
 
 describe("lsp_stop_on_restore", function()
   local as = require("auto-session")
@@ -31,5 +32,32 @@ describe("lsp_stop_on_restore", function()
     as.auto_restore_session_at_vim_enter()
 
     assert.False(stop_called)
+  end)
+
+  it("stops each active client via Client:stop on restore", function()
+    local stopped = {}
+    local get_clients = stub(vim.lsp, "get_clients")
+    get_clients.returns({
+      {
+        stop = function()
+          table.insert(stopped, "client-1")
+        end,
+      },
+      {
+        stop = function()
+          table.insert(stopped, "client-2")
+        end,
+      },
+    })
+
+    as.setup({
+      lsp_stop_on_restore = true,
+    })
+
+    as.restore_session()
+
+    vim.lsp.get_clients:revert()
+
+    assert.same({ "client-1", "client-2" }, stopped)
   end)
 end)


### PR DESCRIPTION
`vim.lsp.stop_client` is deprecated as of v0.11.x

I noticed a deprecation warning when using `lsp_stop_on_restore`

Note:
- https://neovim.io/doc/user/lsp/#Client%3Astop()
- https://neovim.io/doc/user/deprecated/#vim.lsp.stop_client()

For transparency:

This PR was created with the assistance of Codex CLI. If its not to the standard of the project, please feel free to close. 