### PR TITLE
fix: preserve raw session display components

### DIFF
--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -820,11 +820,12 @@ function Lib.get_session_list(sessions_dir)
       end
     end
 
+    local display_name_component_for_display = display_name_component
     if shorten_paths then
-      display_name_component = Lib.shorten_path(display_name_component)
+      display_name_component_for_display = Lib.shorten_path(display_name_component_for_display)
     end
 
-    local display_name = display_name_component .. annotation
+    local display_name = display_name_component_for_display .. annotation
 
     return {
       session_name = session_name,

--- a/tests/cmds_spec.lua
+++ b/tests/cmds_spec.lua
@@ -40,7 +40,7 @@ describe("The default config", function()
     assert.equal(1, #sessions)
 
     assert.equal(TL.session_dir .. sessions[1].file_name, TL.default_session_path)
-    assert.equal(sessions[1].display_name, Lib.current_session_name())
+    assert.equal(Lib.shorten_path(Lib.current_session_name()), sessions[1].display_name)
     assert.equal(sessions[1].session_name, TL.default_session_name)
   end)
 

--- a/tests/cwd_change_handling_spec.lua
+++ b/tests/cwd_change_handling_spec.lua
@@ -50,7 +50,9 @@ describe("The cwd_change_handling config", function()
     assert.True(vim.v.this_session ~= "")
 
     vim.cmd("cd tests")
-    vim.wait(0)
+    vim.wait(1000, function()
+      return post_cwd_changed_hook_called
+    end)
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
     assert.equals(true, pre_cwd_changed_hook_called)
@@ -67,7 +69,9 @@ describe("The cwd_change_handling config", function()
     no_restore_hook_called = false
 
     vim.cmd("cd ..")
-    vim.wait(0)
+    vim.wait(1000, function()
+      return require("auto-session.lib").current_session_name() == vim.fn.getcwd()
+    end)
 
     assert.False(no_restore_hook_called)
     assert.equals(vim.fn.getcwd(), require("auto-session.lib").current_session_name())
@@ -78,7 +82,9 @@ describe("The cwd_change_handling config", function()
   it("does not double load a session when using SessionRestore", function()
     -- Move to different directory
     vim.cmd("cd tests")
-    vim.wait(0)
+    vim.wait(1000, function()
+      return vim.v.this_session == ""
+    end)
 
     pre_cwd_changed_hook_called = false
     post_cwd_changed_hook_called = false

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -76,7 +76,7 @@ describe("The git config", function()
     assert.equal(1, #sessions)
 
     assert.equal(TL.session_dir .. sessions[1].file_name, branch_session_path)
-    assert.equal(sessions[1].display_name, Lib.current_session_name())
+    assert.equal(Lib.shorten_path(vim.fn.getcwd()) .. " (branch: main)", sessions[1].display_name)
     assert.equal(sessions[1].session_name, vim.fn.getcwd() .. "|main")
   end)
 

--- a/tests/legacy_api_spec.lua
+++ b/tests/legacy_api_spec.lua
@@ -33,7 +33,7 @@ describe("legacy api functions", function()
     assert.equal(1, #sessions)
 
     assert.equal(TL.session_dir .. sessions[1].file_name, TL.default_session_path)
-    assert.equal(sessions[1].display_name, Lib.current_session_name())
+    assert.equal(Lib.shorten_path(Lib.current_session_name()), sessions[1].display_name)
     assert.equal(sessions[1].session_name, TL.default_session_name)
   end)
 

--- a/tests/legacy_cmds_spec.lua
+++ b/tests/legacy_cmds_spec.lua
@@ -33,7 +33,7 @@ describe("legacy_cmds=true", function()
     assert.equal(1, #sessions)
 
     assert.equal(TL.session_dir .. sessions[1].file_name, TL.default_session_path)
-    assert.equal(sessions[1].display_name, Lib.current_session_name())
+    assert.equal(Lib.shorten_path(Lib.current_session_name()), sessions[1].display_name)
     assert.equal(sessions[1].session_name, TL.default_session_name)
   end)
 

--- a/tests/lib_spec.lua
+++ b/tests/lib_spec.lua
@@ -316,7 +316,7 @@ describe("Lib / Helper functions", function()
     local session_list = Lib.get_session_list(test_sessions_dir)
     assert.equals(1, #session_list)
     assert.equals("~/myproject", session_list[1].display_name)
-    assert.equals("~/myproject", session_list[1].display_name_component)
+    assert.equals(home .. "/myproject", session_list[1].display_name_component)
 
     vim.fn.delete(test_sessions_dir, "rf")
     Config.setup({})


### PR DESCRIPTION
## Summary
- Keep `display_name_component` as the raw session path component so filesystem checks like orphan purging do not see `~/...` paths.
- Continue shortening picker-facing `display_name` values when `session_lens.shorten_paths` is enabled.
- Update affected specs to distinguish picker display names from canonical session names.

## Testing
- `make tests/git_spec.lua`
- `make test`

Fixes the regression surfaced by https://github.com/rmagatti/auto-session/actions/runs/25334426210 after PR #525.