### PR TITLE
Guard blank buffer checks during exit

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,5 @@
 *auto-session.txt*
-                                        For Neovim    Last change: 2026 May 04
+                                        For Neovim    Last change: 2026 May 20
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*

--- a/lua/auto-session/lib.lua
+++ b/lua/auto-session/lib.lua
@@ -990,13 +990,29 @@ function Lib.only_blank_buffers_left()
   for _, bufnr in ipairs(bufs) do
     -- Only consider listed buffers
     if vim.fn.buflisted(bufnr) == 1 then
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-      local is_empty = #lines <= 1 and (lines[1] == nil or lines[1] == "")
-      local is_modified = vim.api.nvim_get_option_value("modified", { buf = bufnr })
-      local has_name = vim.api.nvim_buf_get_name(bufnr) ~= ""
+      local ok_name, buf_name = pcall(vim.api.nvim_buf_get_name, bufnr)
+      local ok_modified, is_modified = pcall(vim.api.nvim_get_option_value, "modified", { buf = bufnr })
 
-      -- If buffer has a name, is modified, or has content, it's meaningful
-      if has_name or is_modified or not is_empty then
+      if not ok_name or not ok_modified then
+        return false
+      end
+
+      local has_name = buf_name ~= ""
+
+      if has_name or is_modified then
+        return false
+      end
+
+      local ok_lines, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, 0, -1, false)
+
+      if not ok_lines or lines == nil then
+        return false
+      end
+
+      local is_empty = #lines <= 1 and (lines[1] == nil or lines[1] == "")
+
+      -- If buffer has content, it's meaningful
+      if not is_empty then
         return false
       end
     end

--- a/tests/lib_spec.lua
+++ b/tests/lib_spec.lua
@@ -242,6 +242,24 @@ describe("Lib / Helper functions", function()
     assert.True(vim.tbl_isempty(output))
   end)
 
+  it("only_blank_buffers_left is false when buffer lines can't be read", function()
+    TL.clearSessionFilesAndBuffers()
+    vim.cmd("enew")
+
+    local original_get_lines = vim.api.nvim_buf_get_lines
+    local ok, result = pcall(function()
+      vim.api.nvim_buf_get_lines = function()
+        return nil
+      end
+
+      return Lib.only_blank_buffers_left()
+    end)
+    vim.api.nvim_buf_get_lines = original_get_lines
+
+    assert.True(ok)
+    assert.False(result)
+  end)
+
   it("get_session_list filters out nil entries from extra command files", function()
     local test_sessions_dir = TL.session_dir .. "test_sessions/"
     vim.fn.mkdir(test_sessions_dir, "p")


### PR DESCRIPTION
## Summary
- Guard `only_blank_buffers_left()` against transient unreadable buffers during shutdown.
- Treat nil/failed buffer line reads as meaningful buffers so autosave does not crash or auto-delete based on uncertain state.
- Add regression coverage for `nvim_buf_get_lines()` returning nil.

Fixes #528

## Tests
- `make tests/lib_spec.lua`
- `make tests/auto_delete_spec.lua`
- `make test`