### PR TITLE
feat: optionally resolve symlink session paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ local defaults = {
   git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
   git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
   custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+  resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
 
   -- Deleting
   auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving
@@ -155,6 +156,7 @@ local defaults = {
 ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
 ---@field git_auto_restore_on_branch_change? boolean
 ---@field custom_session_tag? fun(session_name:string): tag:string
+---@field resolve_symlinks? boolean
 ---
 ---Deleting
 ---@field auto_delete_empty_sessions? boolean

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -101,6 +101,7 @@ Default settings (you don’t have to copy these into your config):
       git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
       git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
       custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+      resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
     
       -- Deleting
       auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving
@@ -175,6 +176,7 @@ Types ~
     ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
     ---@field git_auto_restore_on_branch_change? boolean
     ---@field custom_session_tag? fun(session_name:string): tag:string
+    ---@field resolve_symlinks? boolean
     ---
     ---Deleting
     ---@field auto_delete_empty_sessions? boolean

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,5 @@
 *auto-session.txt*
-                                        For Neovim    Last change: 2026 May 20
+                                       For Neovim    Last change: 2026 June 08
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*

--- a/lua/auto-session/config.lua
+++ b/lua/auto-session/config.lua
@@ -28,6 +28,7 @@ local M = {}
 ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
 ---@field git_auto_restore_on_branch_change? boolean
 ---@field custom_session_tag? fun(session_name:string): tag:string
+---@field resolve_symlinks? boolean
 ---
 ---Deleting
 ---@field auto_delete_empty_sessions? boolean
@@ -109,6 +110,7 @@ local defaults = {
   git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
   git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
   custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+  resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
 
   -- Deleting
   auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving

--- a/lua/auto-session/init.lua
+++ b/lua/auto-session/init.lua
@@ -34,6 +34,24 @@ function AutoSession.setup(config)
   Lib.logger.debug("Saving argv at setup: " .. vim.inspect(launch_argv))
 end
 
+local function normalize_session_path(path)
+  if Config.resolve_symlinks then
+    path = vim.fn.resolve(path)
+  end
+
+  return Lib.remove_trailing_separator(path)
+end
+
+local function get_current_dir_session_name()
+  local cwd = vim.fn.getcwd(-1, -1)
+
+  if Config.resolve_symlinks then
+    return normalize_session_path(cwd)
+  end
+
+  return cwd
+end
+
 ---Determines the session name based on current state and parameters
 ---@param legacy? boolean Whether to use legacy session name format
 ---@param use_cwd? boolean Whether to force using current working directory (ignoring manually named sessions)
@@ -47,7 +65,7 @@ local function get_session_name(legacy, use_cwd)
     return session_name
   end
 
-  local cwd = vim.fn.getcwd(-1, -1)
+  local cwd = get_current_dir_session_name()
   local git_branch_name = Config.git_use_branch_name and Lib.get_git_branch_name(nil, Config.git_use_branch_name) or nil
   local custom_tag = Config.custom_session_tag and Config.custom_session_tag(cwd) or nil
 
@@ -187,7 +205,7 @@ local function suppress_session(session_dir)
 
   -- If session_dir is set, use that otherwise use cwd
   -- session_dir will be set when loading a session from a directory at launch (i.e. from argv)
-  local cwd = session_dir or vim.fn.getcwd(-1, -1)
+  local cwd = session_dir or get_current_dir_session_name()
 
   if Lib.find_matching_directory(cwd, dirs) then
     Lib.logger.debug("suppress_session found a match, suppressing")
@@ -204,7 +222,7 @@ local function is_allowed_dir()
   end
 
   local dirs = Config.allowed_dirs or {}
-  local cwd = vim.fn.getcwd(-1, -1)
+  local cwd = get_current_dir_session_name()
 
   if Lib.find_matching_directory(cwd, dirs) then
     Lib.logger.debug("is_allowed_dir found a match, allowing")
@@ -549,7 +567,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
   then
     -- Get the full path of the directory and make sure it doesn't have a trailing path_separator
     -- to make sure we find the session
-    local session_name = Lib.remove_trailing_separator(vim.fn.fnamemodify(launch_argv[1], ":p"))
+    local session_name = normalize_session_path(vim.fn.fnamemodify(launch_argv[1], ":p"))
     Lib.logger.debug("Launched with single directory, using as session_dir: " .. session_name)
 
     if Config.git_use_branch_name then
@@ -566,7 +584,7 @@ function AutoSession.auto_restore_session_at_vim_enter()
 
     -- We failed to load a session for the other directory. Unless session name matches cwd, we don't
     -- want to enable autosaving since it might replace the session for the cwd
-    if vim.fn.getcwd(-1, -1) ~= session_name then
+    if get_current_dir_session_name() ~= session_name then
       Lib.logger.debug("Not enabling autosave because launch argument didn't load session and doesn't match cwd")
       Config.auto_save = false
     end
@@ -886,7 +904,7 @@ function AutoSession.restore_session_file(session_path, opts)
 
   if Config.git_use_branch_name and Config.git_auto_restore_on_branch_change then
     -- start watching for branch changes
-    require("auto-session.git").start_watcher(vim.fn.getcwd(-1, -1), ".git/HEAD")
+    require("auto-session.git").start_watcher(get_current_dir_session_name(), ".git/HEAD")
   end
 
   AutoSession.run_cmds("post_restore", session_name)

--- a/tests/args_single_dir_enabled_spec.lua
+++ b/tests/args_single_dir_enabled_spec.lua
@@ -1,6 +1,24 @@
 ---@diagnostic disable: undefined-field
 local TL = require("tests/test_lib")
 local stub = require("luassert.stub")
+local Lib = require("auto-session.lib")
+
+local uv = vim.uv or vim.loop
+
+local function make_symlink_dirs()
+  local base = vim.fn.tempname()
+  local real_dir = base .. "/real"
+  local link_dir = base .. "/link"
+
+  assert.equals(1, vim.fn.mkdir(real_dir, "p"))
+  assert.True(uv.fs_symlink(real_dir, link_dir))
+
+  return {
+    base = base,
+    real = Lib.remove_trailing_separator(vim.fn.resolve(vim.fn.fnamemodify(real_dir, ":p"))),
+    link = Lib.remove_trailing_separator(vim.fn.fnamemodify(link_dir, ":p")),
+  }
+end
 
 describe("The args single dir enabled config", function()
   local no_restore_hook_called = false
@@ -106,5 +124,101 @@ describe("The args single dir enabled config", function()
     assert.equals(true, no_restore_hook_called)
 
     assert.equals(0, vim.fn.bufexists(TL.test_file))
+  end)
+
+  it("does not resolve symlink directory arguments by default", function()
+    if vim.fn.has("win32") == 1 then
+      return
+    end
+
+    no_restore_hook_called = false
+    local cwd = vim.fn.getcwd(-1, -1)
+    local dirs = make_symlink_dirs()
+    c.auto_save = true
+    c.resolve_symlinks = false
+
+    vim.cmd("cd " .. vim.fn.fnameescape(dirs.link))
+
+    local s = stub(vim.fn, "argv")
+    s.returns({ dirs.link })
+
+    as.setup(c.options)
+
+    assert.False(as.auto_restore_session_at_vim_enter())
+    assert.equals(true, no_restore_hook_called)
+
+    -- The symlink argv path and resolved cwd do not match, so autosave stays disabled.
+    assert.False(as.auto_save_session())
+
+    vim.fn.argv:revert()
+    vim.cmd("cd " .. vim.fn.fnameescape(cwd))
+    vim.fn.delete(dirs.base, "rf")
+    c.auto_save = false
+  end)
+
+  it("keeps autosave enabled for symlink directory arguments when resolving symlinks", function()
+    if vim.fn.has("win32") == 1 then
+      return
+    end
+
+    no_restore_hook_called = false
+    local cwd = vim.fn.getcwd(-1, -1)
+    local dirs = make_symlink_dirs()
+    local test_file = dirs.real .. "/test.txt"
+    c.auto_save = true
+    c.resolve_symlinks = true
+
+    vim.fn.writefile({ "test" }, test_file)
+    vim.cmd("cd " .. vim.fn.fnameescape(dirs.link))
+    vim.cmd("e " .. vim.fn.fnameescape(test_file))
+
+    local s = stub(vim.fn, "argv")
+    s.returns({ dirs.link })
+
+    as.setup(c.options)
+
+    assert.False(as.auto_restore_session_at_vim_enter())
+    assert.equals(true, no_restore_hook_called)
+    assert.True(as.auto_save_session())
+    assert.equals(1, vim.fn.filereadable(TL.makeSessionPath(dirs.real)))
+
+    vim.fn.argv:revert()
+    vim.cmd("cd " .. vim.fn.fnameescape(cwd))
+    vim.fn.delete(dirs.base, "rf")
+    c.auto_save = false
+    c.resolve_symlinks = false
+  end)
+
+  it("restores real path sessions with symlink directory arguments when resolving symlinks", function()
+    if vim.fn.has("win32") == 1 then
+      return
+    end
+
+    no_restore_hook_called = false
+    local cwd = vim.fn.getcwd(-1, -1)
+    local dirs = make_symlink_dirs()
+    local test_file = dirs.real .. "/test.txt"
+    c.resolve_symlinks = true
+
+    vim.fn.writefile({ "test" }, test_file)
+    vim.cmd("cd " .. vim.fn.fnameescape(dirs.real))
+    vim.cmd("e " .. vim.fn.fnameescape(test_file))
+    assert.True(as.save_session(nil, { show_message = false }))
+    vim.cmd("%bw!")
+    vim.cmd("cd " .. vim.fn.fnameescape(cwd))
+
+    local s = stub(vim.fn, "argv")
+    s.returns({ dirs.link })
+
+    as.setup(c.options)
+
+    assert.True(as.auto_restore_session_at_vim_enter())
+    assert.equals(false, no_restore_hook_called)
+    assert.equals(1, vim.fn.bufexists(test_file))
+
+    vim.fn.argv:revert()
+    vim.cmd("cd " .. vim.fn.fnameescape(cwd))
+    vim.fn.delete(dirs.base, "rf")
+    c.resolve_symlinks = false
   end)
 end)


### PR DESCRIPTION
## Summary
- add a default-false resolve_symlinks option for cwd-derived session names
- resolve single-directory launch args when opted in so symlink paths can share sessions with real paths
- add symlink startup coverage and document the new option

## Tests
- make tests/args_single_dir_enabled_spec.lua
- make plenary-tests
- make mini-tests
- git diff --check