### PR TITLE
test: skip snacks_terminal close test on windows

### DIFF
--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -1,5 +1,5 @@
 *auto-session.txt*
-                                      For Neovim    Last change: 2026 April 15
+                                     For Neovim    Last change: 2026 August 15
 
 ==============================================================================
 Table of Contents                             *auto-session-table-of-contents*
@@ -101,6 +101,7 @@ Default settings (you don’t have to copy these into your config):
       git_use_branch_name = false, -- Include git branch name in session name, can also be a function that takes an optional path and returns the name of the branch
       git_auto_restore_on_branch_change = false, -- Should we auto-restore the session when the git branch changes. Requires git_use_branch_name
       custom_session_tag = nil, -- Function that can return a string to be used as part of the session name
+      resolve_symlinks = false, -- Resolve symlinks in cwd and single-directory launch arguments before saving/restoring sessions
     
       -- Deleting
       auto_delete_empty_sessions = true, -- Enables/disables deleting the session if there are only unnamed/empty buffers when auto-saving
@@ -130,6 +131,7 @@ Default settings (you don’t have to copy these into your config):
         load_on_setup = true, -- Only used for telescope, registers the telescope extension at startup so you can use :Telescope session-lens
         picker_opts = nil, -- Table passed to Telescope / Snacks / Fzf-Lua to configure the picker. See below for more information
         previewer = "summary", -- 'summary'|'active_buffer'|function - How to display session preview. 'summary' shows a summary of the session, 'active_buffer' shows the contents of the active buffer in the session, or a custom function
+        shorten_paths = true, -- Replace the home directory with ~ in the picker display names
     
         ---@type SessionLensMappings
         mappings = {
@@ -174,6 +176,7 @@ Types ~
     ---@field git_use_branch_name? boolean|fun(path:string?): branch_name:string|nil
     ---@field git_auto_restore_on_branch_change? boolean
     ---@field custom_session_tag? fun(session_name:string): tag:string
+    ---@field resolve_symlinks? boolean
     ---
     ---Deleting
     ---@field auto_delete_empty_sessions? boolean
@@ -205,6 +208,7 @@ Types ~
     ---@field load_on_setup? boolean
     ---@field picker_opts? table
     ---@field previewer? 'summary'|'active_buffer'|fun(session_name:string, session_filename:string, session_lines:string[]):lines:string[],filetype:string?
+    ---@field shorten_paths? boolean
     ---@field mappings? SessionLensMappings
     ---@field session_control? SessionControl
     ---

--- a/tests/close_filetypes_on_save_spec.lua
+++ b/tests/close_filetypes_on_save_spec.lua
@@ -88,49 +88,53 @@ describe("Close filetypes on save", function()
 
   TL.clearSessionFilesAndBuffers()
 
-  it("gracefully closes snacks_terminal buffers before saving", function()
-    local notifications = {}
-    local original_notify = vim.notify
+  -- The test terminal needs a POSIX shell that can read lines from stdin so it
+  -- can't run with the default Windows shell
+  if vim.fn.has("win32") == 0 then
+    it("gracefully closes snacks_terminal buffers before saving", function()
+      local notifications = {}
+      local original_notify = vim.notify
 
-    vim.notify = function(msg, level, opts)
-      table.insert(notifications, { msg = msg, level = level, opts = opts })
-    end
+      vim.notify = function(msg, level, opts)
+        table.insert(notifications, { msg = msg, level = level, opts = opts })
+      end
 
-    vim.cmd("enew")
-    local terminal_buf = vim.api.nvim_get_current_buf()
+      vim.cmd("enew")
+      local terminal_buf = vim.api.nvim_get_current_buf()
 
-    local terminal_closed = false
-    vim.api.nvim_create_autocmd("TermClose", {
-      buffer = terminal_buf,
-      callback = function()
-        if type(vim.v.event) == "table" and vim.v.event.status ~= 0 then
-          vim.notify("Terminal exited with code " .. vim.v.event.status .. ".\nCheck for any errors.")
-          return
-        end
-        terminal_closed = true
-      end,
-    })
+      local terminal_closed = false
+      vim.api.nvim_create_autocmd("TermClose", {
+        buffer = terminal_buf,
+        callback = function()
+          if type(vim.v.event) == "table" and vim.v.event.status ~= 0 then
+            vim.notify("Terminal exited with code " .. vim.v.event.status .. ".\nCheck for any errors.")
+            return
+          end
+          terminal_closed = true
+        end,
+      })
 
-    vim.fn.termopen({ vim.o.shell, "-c", "while IFS= read -r line; do [ \"$line\" = exit ] && exit 0; done" })
-    vim.bo[terminal_buf].filetype = "snacks_terminal"
+      vim.fn.termopen({ vim.o.shell, "-c", 'while IFS= read -r line; do [ "$line" = exit ] && exit 0; done' })
+      vim.bo[terminal_buf].filetype = "snacks_terminal"
 
-    as.setup({
-      close_filetypes_on_save = { "snacks_terminal" },
-    })
+      as.setup({
+        close_filetypes_on_save = { "snacks_terminal" },
+      })
 
-    local ok = pcall(as.auto_save_session)
+      local ok = pcall(as.auto_save_session)
 
-    vim.notify = original_notify
+      vim.notify = original_notify
 
-    assert.True(ok)
-    vim.wait(1000, function()
-      return terminal_closed
-    end, 10)
-    assert.True(terminal_closed)
-    assert.False(vim.api.nvim_buf_is_valid(terminal_buf))
+      assert.True(ok)
+      vim.wait(1000, function()
+        return terminal_closed
+      end, 10)
+      assert.True(terminal_closed)
+      assert.False(vim.api.nvim_buf_is_valid(terminal_buf))
 
-    for _, notification in ipairs(notifications) do
-      assert.is_nil(notification.msg:match("Terminal exited with code %-1"))
-    end
-  end)
+      for _, notification in ipairs(notifications) do
+        assert.is_nil(notification.msg:match("Terminal exited with code %-1"))
+      end
+    end)
+  end
 end)


### PR DESCRIPTION
The snacks_terminal graceful-close test added in #518 fails on Windows because its fake terminal requires a POSIX shell reading lines from stdin. The plugin change itself is fine on Windows (cmd/powershell both honor a sent `exit`, and there's a force-delete fallback). Wrapping the test in the established `vim.fn.has("win32") == 0` guard.