### PR TITLE
docs: fix quickfix recipe and clarify cancellation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,10 @@ Command hooks exist in the format: {hook_name}
 - `{post_cwd_changed}`: executes _after_ a directory is changed (if `cwd_change_handling` is enabled)
 - `{save_extra}`: executes _after_ a session is saved, saves returned string or table to `*x.vim`, reference `:help mks`
 
+Note that returning `false` from `{pre_save}`/`{pre_restore}` only prevents an **automatic** save/restore on exit/startup. It does not cancel an explicitly invoked command like `:AutoSession save` or `:AutoSession restore`.
+
+Before reaching for these hooks to skip saving or restoring, check whether one of AutoSession's built-in options already handles the case declaratively: `bypass_save_filetypes` (e.g. skip saving dashboard-only sessions), `suppressed_dirs`/`allowed_dirs` (directory filtering), `auto_delete_empty_sessions` (empty sessions) and `close_filetypes_on_save` (buffers that shouldn't end up in the session). The cancellation hooks are best reserved for dynamic or project-specific conditions that can't be expressed through those options.
+
 Each hook is a table of vim commands or lua functions (or a mix of both). Here are some examples of what you can do:
 
 ```lua
@@ -546,8 +550,16 @@ opts = {
       local qfinfo = vim.fn.getqflist({ title = 1 })
 
       for _, entry in ipairs(qflist) do
-        -- use filename instead of bufnr so it can be reloaded
-        entry.filename = vim.api.nvim_buf_get_name(entry.bufnr)
+        -- use filename instead of bufnr so it can be reloaded. Entries with no
+        -- buffer (e.g. non-error lines from build output) have bufnr 0, which
+        -- would otherwise resolve to the current buffer, so leave them fileless
+        local bufnr = entry.bufnr
+        if type(bufnr) == "number" and bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
+          local filename = vim.api.nvim_buf_get_name(bufnr)
+          if filename ~= "" then
+            entry.filename = filename
+          end
+        end
         entry.bufnr = nil
       end
 

--- a/doc/auto-session.txt
+++ b/doc/auto-session.txt
@@ -571,6 +571,19 @@ Command hooks exist in the format: {hook_name}
 - `{post_cwd_changed}`: executes _after_ a directory is changed (if `cwd_change_handling` is enabled)
 - `{save_extra}`: executes _after_ a session is saved, saves returned string or table to `*x.vim`, reference `:help mks`
 
+Note that returning `false` from `{pre_save}`/`{pre_restore}` only prevents an
+**automatic** save/restore on exit/startup. It does not cancel an explicitly
+invoked command like `:AutoSession save` or `:AutoSession restore`.
+
+Before reaching for these hooks to skip saving or restoring, check whether one
+of AutoSession’s built-in options already handles the case declaratively:
+`bypass_save_filetypes` (e.g. skip saving dashboard-only sessions),
+`suppressed_dirs`/`allowed_dirs` (directory filtering),
+`auto_delete_empty_sessions` (empty sessions) and `close_filetypes_on_save`
+(buffers that shouldn’t end up in the session). The cancellation hooks are
+best reserved for dynamic or project-specific conditions that can’t be
+expressed through those options.
+
 Each hook is a table of vim commands or lua functions (or a mix of both). Here
 are some examples of what you can do:
 
@@ -620,8 +633,16 @@ are some examples of what you can do:
           local qfinfo = vim.fn.getqflist({ title = 1 })
     
           for _, entry in ipairs(qflist) do
-            -- use filename instead of bufnr so it can be reloaded
-            entry.filename = vim.api.nvim_buf_get_name(entry.bufnr)
+            -- use filename instead of bufnr so it can be reloaded. Entries with no
+            -- buffer (e.g. non-error lines from build output) have bufnr 0, which
+            -- would otherwise resolve to the current buffer, so leave them fileless
+            local bufnr = entry.bufnr
+            if type(bufnr) == "number" and bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
+              local filename = vim.api.nvim_buf_get_name(bufnr)
+              if filename ~= "" then
+                entry.filename = filename
+              end
+            end
             entry.bufnr = nil
           end
     


### PR DESCRIPTION
Two docs-only fixes from issue triage:

**#538**: the README quickfix recipe converted every qflist entry's bufnr to a filename, but entries without a buffer (e.g. non-error lines from build output) have `bufnr = 0`, which Neovim APIs interpret as the current buffer. Now only valid, positive, named buffer references are converted; other entries stay fileless.

**#536**: clarifies in the Command Hooks section that (1) returning false from pre_save/pre_restore only cancels *automatic* save/restore, not explicit commands, and (2) built-in options (bypass_save_filetypes, suppressed_dirs/allowed_dirs, auto_delete_empty_sessions, close_filetypes_on_save) should be preferred for common filtering cases, with hooks as escape hatches for dynamic conditions.

Fixes #538, closes #536